### PR TITLE
refactor(shared/api): Phase 1-2 code review fixes

### DIFF
--- a/apps/api/__init__.py
+++ b/apps/api/__init__.py
@@ -1,0 +1,3 @@
+"""FastAPI service for credit risk modeling."""
+
+__version__ = "0.1.0"

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
 
     app_name: str = "Credit Risk API"
     debug: bool = False
-    default_dataset_path: str = "data/raw/cr_loan_w2.csv"
+    default_dataset_path: str = "data/processed/cr_loan_w2.csv"
     model_artifacts_path: str = "artifacts/"
     log_level: str = "INFO"
     cors_origins: list[str] = ["*"]  # Allow all for dev, restrict in production

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -1,0 +1,25 @@
+"""Application configuration using pydantic-settings."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """API configuration settings.
+
+    Attributes:
+        app_name: Application name.
+        debug: Enable debug mode.
+        default_dataset_path: Path to default training dataset.
+        model_artifacts_path: Directory for persisted model artifacts.
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        cors_origins: List of allowed CORS origins.
+    """
+
+    app_name: str = "Credit Risk API"
+    debug: bool = False
+    default_dataset_path: str = "data/raw/cr_loan_w2.csv"
+    model_artifacts_path: str = "artifacts/"
+    log_level: str = "INFO"
+    cors_origins: list[str] = ["*"]  # Allow all for dev, restrict in production
+
+    model_config = SettingsConfigDict(env_prefix="CREDIT_RISK_")

--- a/apps/api/dependencies.py
+++ b/apps/api/dependencies.py
@@ -1,0 +1,19 @@
+"""FastAPI dependency injection providers."""
+
+from functools import lru_cache
+
+from apps.api.config import Settings
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Get cached application settings.
+
+    Returns:
+        Application settings loaded from environment.
+
+    Example:
+        >>> settings = get_settings()
+        >>> assert settings.app_name == "Credit Risk API"
+    """
+    return Settings()

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,0 +1,92 @@
+"""FastAPI application factory and configuration."""
+
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from apps.api.config import Settings
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Application lifespan context manager.
+
+    Handles startup and shutdown events for the FastAPI application.
+
+    Args:
+        app: FastAPI application instance.
+
+    Yields:
+        None during application runtime.
+    """
+    # Startup
+    logger.info("Starting Credit Risk API...")
+    logger.info(f"Environment: {'development' if app.debug else 'production'}")
+
+    yield
+
+    # Shutdown
+    logger.info("Shutting down Credit Risk API...")
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure FastAPI application.
+
+    Args:
+        settings: Application settings. If None, loads from environment.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    if settings is None:
+        settings = Settings()
+
+    # Create FastAPI app
+    app = FastAPI(
+        title=settings.app_name,
+        version="0.1.0",
+        description="Train and deploy credit risk models via REST API",
+        debug=settings.debug,
+        lifespan=lifespan,
+    )
+
+    # Configure CORS
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Health check endpoint
+    @app.get("/health", tags=["health"])
+    async def health_check() -> dict[str, str]:
+        """Health check endpoint.
+
+        Returns:
+            Status message indicating API is healthy.
+        """
+        return {"status": "ok", "service": settings.app_name}
+
+    # Include routers (will be added later)
+    # from apps.api.routers import train, predict, models
+    # app.include_router(train.router, prefix="/train", tags=["training"])
+    # app.include_router(predict.router, prefix="/predict", tags=["prediction"])
+    # app.include_router(models.router, prefix="/models", tags=["models"])
+
+    return app
+
+
+# Application instance for uvicorn
+app = create_app()

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -79,11 +79,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         """
         return {"status": "ok", "service": settings.app_name}
 
-    # Include routers (will be added later)
-    # from apps.api.routers import train, predict, models
-    # app.include_router(train.router, prefix="/train", tags=["training"])
-    # app.include_router(predict.router, prefix="/predict", tags=["prediction"])
-    # app.include_router(models.router, prefix="/models", tags=["models"])
+    # Include routers
+    from apps.api.routers import models, predict, train
+
+    app.include_router(train.router, prefix="/train", tags=["training"])
+    app.include_router(predict.router, prefix="/predict", tags=["prediction"])
+    app.include_router(models.router, prefix="/models", tags=["models"])
 
     return app
 

--- a/apps/api/routers/__init__.py
+++ b/apps/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers for train, predict, and model management endpoints."""

--- a/apps/api/routers/models.py
+++ b/apps/api/routers/models.py
@@ -1,0 +1,156 @@
+"""Model management endpoint router."""
+
+import json
+import pickle
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from apps.api.config import Settings
+from apps.api.dependencies import get_settings
+from apps.api.services.model_store import ModelMetadata, get_model, list_models
+
+router = APIRouter()
+
+
+class PersistResponse(BaseModel):
+    """Response from model persistence operation.
+
+    Attributes:
+        model_id: ID of the persisted model.
+        path: File path where model was saved.
+        instructions: Instructions for loading the model.
+    """
+
+    model_id: str
+    path: str
+    instructions: str
+
+
+@router.get("/", response_model=list[ModelMetadata])
+async def get_models() -> list[ModelMetadata]:
+    """List all trained models in session.
+
+    Returns:
+        List of model metadata for all stored models.
+
+    Example Response:
+        ```json
+        [
+            {
+                "model_id": "model_a1b2c3d4",
+                "model_type": "logistic_regression",
+                "threshold": 0.47,
+                "roc_auc": 0.88,
+                "accuracy": 0.85,
+                "created_at": "2025-01-31T00:00:00"
+            }
+        ]
+        ```
+    """
+    return list_models()
+
+
+@router.get("/{model_id}", response_model=ModelMetadata)
+async def get_model_metadata(model_id: str) -> ModelMetadata:
+    """Get metadata for a specific model.
+
+    Args:
+        model_id: Model identifier.
+
+    Returns:
+        Model metadata.
+
+    Raises:
+        HTTPException: If model not found.
+    """
+    stored_model = get_model(model_id)
+    if stored_model is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+
+    return stored_model.metadata
+
+
+@router.post("/{model_id}/persist", response_model=PersistResponse)
+async def persist_model(
+    model_id: str,
+    settings: Settings = Depends(get_settings)
+) -> PersistResponse:
+    """Persist a trained model to disk.
+
+    Args:
+        model_id: Model identifier to persist.
+        settings: Application settings (injected).
+
+    Returns:
+        PersistResponse with file path and loading instructions.
+
+    Raises:
+        HTTPException: If model not found or persistence fails.
+
+    Example Response:
+        ```json
+        {
+            "model_id": "model_a1b2c3d4",
+            "path": "artifacts/model_a1b2c3d4.pkl",
+            "instructions": "Load with: import pickle; ..."
+        }
+        ```
+    """
+    # Retrieve model
+    stored_model = get_model(model_id)
+    if stored_model is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+
+    try:
+        # Create artifacts directory if it doesn't exist
+        artifacts_dir = Path(settings.model_artifacts_path)
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save model
+        model_path = artifacts_dir / f"{model_id}.pkl"
+        with open(model_path, "wb") as f:
+            pickle.dump(stored_model.model, f)
+
+        # Save metadata
+        metadata_path = artifacts_dir / f"{model_id}_metadata.json"
+        with open(metadata_path, "w") as f:
+            json.dump(stored_model.metadata.model_dump(), f, indent=2, default=str)
+
+        # Generate loading instructions
+        instructions = f"""
+To load this model:
+
+```python
+import pickle
+
+# Load model
+with open('{model_path}', 'rb') as f:
+    model = pickle.load(f)
+
+# Load metadata
+import json
+with open('{metadata_path}', 'r') as f:
+    metadata = json.load(f)
+
+# Make predictions
+import numpy as np
+X_new = np.array([...])  # Your feature matrix
+y_proba = model.predict_proba(X_new)[:, 1]
+threshold = metadata['threshold']
+predictions = (y_proba >= threshold).astype(int)
+```
+        """.strip()
+
+        return PersistResponse(
+            model_id=model_id,
+            path=str(model_path),
+            instructions=instructions
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to persist model: {e}"
+        )

--- a/apps/api/routers/models.py
+++ b/apps/api/routers/models.py
@@ -5,27 +5,13 @@ import pickle
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from apps.api.config import Settings
 from apps.api.dependencies import get_settings
-from apps.api.services.model_store import ModelMetadata, get_model, list_models
+from apps.api.services.model_store import get_model, list_models
+from shared.schemas.model import ModelMetadata, PersistResponse
 
 router = APIRouter()
-
-
-class PersistResponse(BaseModel):
-    """Response from model persistence operation.
-
-    Attributes:
-        model_id: ID of the persisted model.
-        path: File path where model was saved.
-        instructions: Instructions for loading the model.
-    """
-
-    model_id: str
-    path: str
-    instructions: str
 
 
 @router.get("/", response_model=list[ModelMetadata])

--- a/apps/api/routers/predict.py
+++ b/apps/api/routers/predict.py
@@ -1,0 +1,75 @@
+"""Prediction endpoint router."""
+
+from fastapi import APIRouter, HTTPException
+
+from apps.api.services.inference import predict
+from shared.schemas.prediction import PredictionRequest, PredictionResponse
+
+router = APIRouter()
+
+
+@router.post("/", response_model=PredictionResponse)
+async def make_predictions(request: PredictionRequest) -> PredictionResponse:
+    """Make predictions for loan applications.
+
+    Args:
+        request: Prediction request with model ID and loan applications.
+
+    Returns:
+        PredictionResponse with predictions for all applications.
+
+    Raises:
+        HTTPException: If model not found or prediction fails.
+
+    Example Request:
+        ```json
+        {
+            "model_id": "model_a1b2c3d4",
+            "applications": [
+                {
+                    "person_age": 25,
+                    "person_income": 50000.0,
+                    "person_emp_length": 3.0,
+                    "loan_amnt": 10000.0,
+                    "loan_int_rate": 10.5,
+                    "loan_percent_income": 0.2,
+                    "cb_person_cred_hist_length": 5,
+                    "person_home_ownership": "RENT",
+                    "loan_intent": "EDUCATION",
+                    "loan_grade": "B",
+                    "cb_person_default_on_file": "N"
+                }
+            ],
+            "threshold": null,
+            "include_probabilities": true
+        }
+        ```
+
+    Example Response:
+        ```json
+        {
+            "model_id": "model_a1b2c3d4",
+            "model_type": "logistic_regression",
+            "threshold": 0.47,
+            "predictions": [
+                {
+                    "application": {...},
+                    "predicted_default": false,
+                    "default_probability": 0.25,
+                    "confidence": 0.47
+                }
+            ],
+            "timestamp": "2025-01-31T00:00:00",
+            "total_applications": 1,
+            "predicted_defaults": 0,
+            "predicted_approvals": 1
+        }
+        ```
+    """
+    try:
+        response = predict(request)
+        return response
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")

--- a/apps/api/routers/predict.py
+++ b/apps/api/routers/predict.py
@@ -1,9 +1,13 @@
 """Prediction endpoint router."""
 
+import logging
+
 from fastapi import APIRouter, HTTPException
 
 from apps.api.services.inference import predict
 from shared.schemas.prediction import PredictionRequest, PredictionResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -71,5 +75,6 @@ async def make_predictions(request: PredictionRequest) -> PredictionResponse:
         return response
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")
+    except Exception:
+        logger.exception("Prediction failed unexpectedly")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/apps/api/routers/train.py
+++ b/apps/api/routers/train.py
@@ -1,11 +1,15 @@
 """Training endpoint router."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from apps.api.config import Settings
 from apps.api.dependencies import get_settings
 from apps.api.services.training import train_model
 from shared.schemas.training import TrainingConfig, TrainingResult
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -72,5 +76,6 @@ async def train(
         raise HTTPException(status_code=404, detail=f"Dataset not found: {e}")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid configuration: {e}")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Training failed: {e}")
+    except Exception:
+        logger.exception("Training failed unexpectedly")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/apps/api/routers/train.py
+++ b/apps/api/routers/train.py
@@ -1,0 +1,76 @@
+"""Training endpoint router."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from apps.api.config import Settings
+from apps.api.dependencies import get_settings
+from apps.api.services.training import train_model
+from shared.schemas.training import TrainingConfig, TrainingResult
+
+router = APIRouter()
+
+
+@router.post("/", response_model=TrainingResult)
+async def train(
+    config: TrainingConfig,
+    settings: Settings = Depends(get_settings)
+) -> TrainingResult:
+    """Train a credit risk model.
+
+    Args:
+        config: Training configuration specifying model type and parameters.
+        settings: Application settings (injected).
+
+    Returns:
+        TrainingResult with model ID, metrics, and optimal threshold.
+
+    Raises:
+        HTTPException: If training fails.
+
+    Example Request:
+        ```json
+        {
+            "model_type": "logistic_regression",
+            "test_size": 0.2,
+            "random_state": 42,
+            "undersample": false,
+            "cv_folds": 5
+        }
+        ```
+
+    Example Response:
+        ```json
+        {
+            "model_id": "model_a1b2c3d4",
+            "model_type": "logistic_regression",
+            "metrics": {
+                "accuracy": 0.85,
+                "precision": 0.82,
+                "recall": 0.79,
+                "f1_score": 0.80,
+                "roc_auc": 0.88,
+                "threshold_analysis": {
+                    "threshold": 0.47,
+                    "sensitivity": 0.79,
+                    "specificity": 0.86,
+                    "youden_j": 0.65,
+                    "precision": 0.82,
+                    "f1_score": 0.80
+                },
+                ...
+            },
+            "optimal_threshold": 0.47,
+            "feature_importance": {"person_age": 0.05, ...},
+            "training_config": {...}
+        }
+        ```
+    """
+    try:
+        result = train_model(config, dataset_path=settings.default_dataset_path)
+        return result
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=f"Dataset not found: {e}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid configuration: {e}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Training failed: {e}")

--- a/apps/api/services/__init__.py
+++ b/apps/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business logic services for training, inference, and audit."""

--- a/apps/api/services/audit.py
+++ b/apps/api/services/audit.py
@@ -1,0 +1,31 @@
+"""Audit event logging service."""
+
+import json
+import logging
+
+from shared.schemas.audit import AuditEvent
+
+# Configure audit logger
+logger = logging.getLogger("audit")
+
+
+def emit_event(event: AuditEvent) -> None:
+    """Emit an audit event to structured logging.
+
+    Args:
+        event: Audit event to log.
+
+    Example:
+        >>> from shared.schemas.audit import TrainingAuditEvent
+        >>> event = TrainingAuditEvent(
+        ...     event_id="evt_123",
+        ...     model_id="model_456",
+        ...     model_type="logistic_regression",
+        ...     training_config={"test_size": 0.2},
+        ...     dataset_size=1000,
+        ...     test_accuracy=0.85
+        ... )
+        >>> emit_event(event)
+    """
+    # Log event as structured JSON
+    logger.info(json.dumps(event.model_dump(), default=str))

--- a/apps/api/services/inference.py
+++ b/apps/api/services/inference.py
@@ -1,0 +1,187 @@
+"""Inference service for model predictions."""
+
+import uuid
+from datetime import datetime
+
+import numpy as np
+from numpy.typing import NDArray
+
+from apps.api.services.audit import emit_event
+from apps.api.services.model_store import get_model
+from shared import constants
+from shared.logic.evaluation import calculate_model_confidence
+from shared.logic.preprocessing import (
+    encode_default_on_file,
+    encode_home_ownership,
+    encode_loan_grade,
+    encode_loan_intent,
+)
+from shared.schemas.audit import PredictionAuditEvent
+from shared.schemas.loan import LoanApplication
+from shared.schemas.prediction import (
+    PredictionRequest,
+    PredictionResponse,
+    PredictionResult,
+)
+
+
+def loan_application_to_features(application: LoanApplication) -> NDArray[np.float64]:
+    """Convert LoanApplication to feature vector.
+
+    Args:
+        application: Loan application with all required fields.
+
+    Returns:
+        Feature vector matching constants.ALL_FEATURES order.
+
+    Example:
+        >>> app = LoanApplication(
+        ...     person_age=25,
+        ...     person_income=50000.0,
+        ...     person_emp_length=3.0,
+        ...     loan_amnt=10000.0,
+        ...     loan_int_rate=10.5,
+        ...     loan_percent_income=0.2,
+        ...     cb_person_cred_hist_length=5,
+        ...     person_home_ownership="RENT",
+        ...     loan_intent="EDUCATION",
+        ...     loan_grade="B",
+        ...     cb_person_default_on_file="N"
+        ... )
+        >>> features = loan_application_to_features(app)
+        >>> assert features.shape == (27,)  # 7 numeric + 20 one-hot encoded
+    """
+    # Numeric features
+    numeric_values = [
+        float(application.person_age),
+        float(application.person_income),
+        float(application.person_emp_length),
+        float(application.loan_amnt),
+        float(application.loan_int_rate),
+        float(application.loan_percent_income),
+        float(application.cb_person_cred_hist_length),
+    ]
+
+    # One-hot encode categorical features
+    # Home ownership
+    home_ownership_encoded = [0.0] * 4  # MORTGAGE, OTHER, OWN, RENT
+    home_map = {"MORTGAGE": 0, "OTHER": 1, "OWN": 2, "RENT": 3}
+    home_ownership_encoded[home_map[application.person_home_ownership]] = 1.0
+
+    # Loan intent
+    loan_intent_encoded = [0.0] * 6  # DEBTCONSOLIDATION, EDUCATION, etc.
+    intent_map = {
+        "DEBTCONSOLIDATION": 0,
+        "EDUCATION": 1,
+        "HOMEIMPROVEMENT": 2,
+        "MEDICAL": 3,
+        "PERSONAL": 4,
+        "VENTURE": 5,
+    }
+    loan_intent_encoded[intent_map[application.loan_intent]] = 1.0
+
+    # Loan grade
+    loan_grade_encoded = [0.0] * 7  # A, B, C, D, E, F, G
+    grade_map = {"A": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5, "G": 6}
+    loan_grade_encoded[grade_map[application.loan_grade]] = 1.0
+
+    # Default on file
+    default_encoded = [0.0, 0.0]  # N, Y
+    default_map = {"N": 0, "Y": 1}
+    default_encoded[default_map[application.cb_person_default_on_file]] = 1.0
+
+    # Combine all features
+    all_features = (
+        numeric_values
+        + home_ownership_encoded
+        + loan_intent_encoded
+        + loan_grade_encoded
+        + default_encoded
+    )
+
+    return np.array(all_features, dtype=np.float64)
+
+
+def predict(request: PredictionRequest) -> PredictionResponse:
+    """Make predictions for loan applications.
+
+    Args:
+        request: Prediction request with model ID and loan applications.
+
+    Returns:
+        Prediction response with results for all applications.
+
+    Raises:
+        ValueError: If model_id is not found.
+
+    Example:
+        >>> request = PredictionRequest(
+        ...     model_id="model_123",
+        ...     applications=[loan_app1, loan_app2]
+        ... )
+        >>> response = predict(request)
+        >>> assert len(response.predictions) == 2
+    """
+    # Retrieve model
+    stored_model = get_model(request.model_id)
+    if stored_model is None:
+        raise ValueError(f"Model not found: {request.model_id}")
+
+    model = stored_model.model
+    metadata = stored_model.metadata
+
+    # Use specified threshold or model's optimal threshold
+    threshold = request.threshold if request.threshold is not None else metadata.threshold
+
+    # Convert applications to feature matrix
+    X = np.array([
+        loan_application_to_features(app)
+        for app in request.applications
+    ])
+
+    # Get predictions
+    y_proba = model.predict_proba(X)[:, 1]  # Probability of default (class 1)
+    y_pred = (y_proba >= threshold).astype(int)
+
+    # Calculate confidence scores
+    confidence_scores = calculate_model_confidence(y_proba, threshold)
+
+    # Build prediction results
+    predictions = [
+        PredictionResult(
+            application=app,
+            predicted_default=bool(pred),
+            default_probability=float(proba),
+            confidence=float(conf)
+        )
+        for app, pred, proba, conf in zip(
+            request.applications, y_pred, y_proba, confidence_scores
+        )
+    ]
+
+    # Count predictions
+    predicted_defaults = int(np.sum(y_pred == 1))
+    predicted_approvals = int(np.sum(y_pred == 0))
+
+    # Emit audit event
+    audit_event = PredictionAuditEvent(
+        event_id=f"evt_{uuid.uuid4().hex[:8]}",
+        model_id=request.model_id,
+        num_predictions=len(predictions),
+        threshold_used=threshold,
+        predicted_defaults=predicted_defaults,
+        avg_default_probability=float(np.mean(y_proba))
+    )
+    emit_event(audit_event)
+
+    # Return prediction response
+    return PredictionResponse(
+        model_id=request.model_id,
+        model_type=metadata.model_type,
+        threshold=threshold,
+        predictions=predictions,
+        timestamp=datetime.now(),
+        total_applications=len(predictions),
+        predicted_defaults=predicted_defaults,
+        predicted_approvals=predicted_approvals
+    )

--- a/apps/api/services/model_store.py
+++ b/apps/api/services/model_store.py
@@ -1,0 +1,135 @@
+"""In-memory model storage service."""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+# In-memory model store (session-scoped, not persisted)
+# In Phase 5, this will be replaced with persistent storage (filesystem, S3, MLflow)
+_model_store: dict[str, dict[str, Any]] = {}
+
+
+class ModelMetadata(BaseModel):
+    """Metadata for a stored model.
+
+    Attributes:
+        model_id: Unique identifier for the model.
+        model_type: Type of ML model (logistic_regression, xgboost, random_forest).
+        threshold: Optimal classification threshold.
+        roc_auc: Area under ROC curve.
+        accuracy: Test set accuracy.
+        created_at: Timestamp when model was trained.
+    """
+
+    model_id: str
+    model_type: str
+    threshold: float
+    roc_auc: float
+    accuracy: float
+    created_at: str
+
+
+class StoredModel(BaseModel):
+    """Complete stored model with metadata.
+
+    Attributes:
+        model: Trained sklearn/xgboost model object.
+        metadata: Model metadata.
+    """
+
+    model: Any  # sklearn or xgboost model
+    metadata: ModelMetadata
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+def store_model(model_id: str, model: Any, metadata: ModelMetadata) -> None:
+    """Store a trained model in memory.
+
+    Args:
+        model_id: Unique identifier for the model.
+        model: Trained model object (sklearn/xgboost).
+        metadata: Model metadata.
+
+    Example:
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> model = LogisticRegression()
+        >>> metadata = ModelMetadata(
+        ...     model_id="model_123",
+        ...     model_type="logistic_regression",
+        ...     threshold=0.5,
+        ...     roc_auc=0.85,
+        ...     accuracy=0.82,
+        ...     created_at="2025-01-31T00:00:00"
+        ... )
+        >>> store_model("model_123", model, metadata)
+    """
+    _model_store[model_id] = {
+        "model": model,
+        "metadata": metadata.model_dump(),
+    }
+
+
+def get_model(model_id: str) -> StoredModel | None:
+    """Retrieve a stored model by ID.
+
+    Args:
+        model_id: Model identifier to retrieve.
+
+    Returns:
+        StoredModel if found, None otherwise.
+
+    Example:
+        >>> stored = get_model("model_123")
+        >>> if stored:
+        ...     print(stored.metadata.model_type)
+        logistic_regression
+    """
+    stored_data = _model_store.get(model_id)
+    if stored_data is None:
+        return None
+
+    return StoredModel(
+        model=stored_data["model"],
+        metadata=ModelMetadata(**stored_data["metadata"]),
+    )
+
+
+def list_models() -> list[ModelMetadata]:
+    """List all stored models' metadata.
+
+    Returns:
+        List of ModelMetadata for all stored models.
+
+    Example:
+        >>> models = list_models()
+        >>> print(len(models))
+        1
+    """
+    return [
+        ModelMetadata(**stored["metadata"])
+        for stored in _model_store.values()
+    ]
+
+
+def delete_model(model_id: str) -> bool:
+    """Delete a stored model.
+
+    Args:
+        model_id: Model identifier to delete.
+
+    Returns:
+        True if model was deleted, False if not found.
+    """
+    if model_id in _model_store:
+        del _model_store[model_id]
+        return True
+    return False
+
+
+def clear_all_models() -> None:
+    """Clear all stored models.
+
+    Used for testing and cleanup.
+    """
+    _model_store.clear()

--- a/apps/api/services/model_store.py
+++ b/apps/api/services/model_store.py
@@ -4,29 +4,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from shared.schemas.model import ModelMetadata
+
 # In-memory model store (session-scoped, not persisted)
 # In Phase 5, this will be replaced with persistent storage (filesystem, S3, MLflow)
 _model_store: dict[str, dict[str, Any]] = {}
-
-
-class ModelMetadata(BaseModel):
-    """Metadata for a stored model.
-
-    Attributes:
-        model_id: Unique identifier for the model.
-        model_type: Type of ML model (logistic_regression, xgboost, random_forest).
-        threshold: Optimal classification threshold.
-        roc_auc: Area under ROC curve.
-        accuracy: Test set accuracy.
-        created_at: Timestamp when model was trained.
-    """
-
-    model_id: str
-    model_type: str
-    threshold: float
-    roc_auc: float
-    accuracy: float
-    created_at: str
 
 
 class StoredModel(BaseModel):
@@ -53,7 +35,6 @@ def store_model(model_id: str, model: Any, metadata: ModelMetadata) -> None:
 
     Example:
         >>> from sklearn.linear_model import LogisticRegression
-        >>> model = LogisticRegression()
         >>> metadata = ModelMetadata(
         ...     model_id="model_123",
         ...     model_type="logistic_regression",
@@ -62,7 +43,7 @@ def store_model(model_id: str, model: Any, metadata: ModelMetadata) -> None:
         ...     accuracy=0.82,
         ...     created_at="2025-01-31T00:00:00"
         ... )
-        >>> store_model("model_123", model, metadata)
+        >>> store_model("model_123", LogisticRegression(), metadata)
     """
     _model_store[model_id] = {
         "model": model,

--- a/apps/api/services/training.py
+++ b/apps/api/services/training.py
@@ -1,0 +1,167 @@
+"""Model training service."""
+
+import uuid
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+from apps.api.services.audit import emit_event
+from apps.api.services.model_store import ModelMetadata, store_model
+from shared import constants
+from shared.logic.evaluation import evaluate_model
+from shared.logic.preprocessing import undersample_majority_class
+from shared.schemas.audit import TrainingAuditEvent
+from shared.schemas.training import TrainingConfig, TrainingResult
+
+
+def load_dataset_from_csv(filepath: str) -> tuple[NDArray[np.float64], NDArray[np.int_]]:
+    """Load dataset from CSV file.
+
+    Args:
+        filepath: Path to CSV file.
+
+    Returns:
+        Tuple of (X, y) where X is feature matrix and y is target labels.
+
+    Raises:
+        FileNotFoundError: If CSV file doesn't exist.
+        ValueError: If required columns are missing.
+    """
+    df = pd.read_csv(filepath)
+
+    # Validate required columns exist
+    if constants.TARGET_COLUMN not in df.columns:
+        raise ValueError(f"Target column '{constants.TARGET_COLUMN}' not found in dataset")
+
+    missing_features = [f for f in constants.ALL_FEATURES if f not in df.columns]
+    if missing_features:
+        raise ValueError(f"Missing feature columns: {missing_features}")
+
+    # Extract features and target
+    X = df[constants.ALL_FEATURES].values.astype(np.float64)
+    y = df[constants.TARGET_COLUMN].values.astype(np.int_)
+
+    return X, y
+
+
+def create_model(model_type: str) -> LogisticRegression | XGBClassifier | RandomForestClassifier:
+    """Create sklearn/xgboost model instance.
+
+    Args:
+        model_type: Type of model to create.
+
+    Returns:
+        Untrained model instance.
+
+    Raises:
+        ValueError: If model_type is not recognized.
+    """
+    if model_type == "logistic_regression":
+        return LogisticRegression(**constants.LOGISTIC_REGRESSION_PARAMS)  # type: ignore
+    elif model_type == "xgboost":
+        return XGBClassifier(**constants.XGBOOST_PARAMS)  # type: ignore
+    elif model_type == "random_forest":
+        return RandomForestClassifier(**constants.RANDOM_FOREST_PARAMS)  # type: ignore
+    else:
+        raise ValueError(f"Unknown model type: {model_type}")
+
+
+def train_model(config: TrainingConfig, dataset_path: str | None = None) -> TrainingResult:
+    """Train a credit risk model.
+
+    Args:
+        config: Training configuration.
+        dataset_path: Path to dataset CSV. If None, uses default.
+
+    Returns:
+        TrainingResult with metrics and model ID.
+
+    Raises:
+        FileNotFoundError: If dataset file doesn't exist.
+        ValueError: If configuration is invalid.
+
+    Example:
+        >>> config = TrainingConfig(model_type="logistic_regression")
+        >>> result = train_model(config, "data/raw/cr_loan_w2.csv")
+        >>> assert result.model_id
+        >>> assert 0 <= result.optimal_threshold <= 1
+    """
+    # Generate unique model ID
+    model_id = f"model_{uuid.uuid4().hex[:8]}"
+    timestamp = datetime.now().isoformat()
+
+    # Load dataset
+    if dataset_path is None:
+        dataset_path = constants.DEFAULT_DATASET_PATH if hasattr(constants, 'DEFAULT_DATASET_PATH') else "data/raw/cr_loan_w2.csv"
+
+    X, y = load_dataset_from_csv(dataset_path)
+
+    # Split dataset
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y,
+        test_size=config.test_size,
+        random_state=config.random_state,
+        stratify=y
+    )
+
+    # Undersample if requested
+    if config.undersample:
+        X_train, y_train = undersample_majority_class(
+            X_train, y_train, random_state=config.random_state
+        )
+
+    # Create and train model
+    model = create_model(config.model_type)
+    model.fit(X_train, y_train)
+
+    # Get predictions on test set
+    y_proba = model.predict_proba(X_test)[:, 1]  # Probability of default (class 1)
+
+    # Evaluate model using shared logic
+    metrics = evaluate_model(y_test, y_proba)
+
+    # Extract feature importance if available
+    feature_importance: dict[str, float] | None = None
+    if hasattr(model, "feature_importances_"):
+        feature_importance = {
+            feature: float(importance)
+            for feature, importance in zip(constants.ALL_FEATURES, model.feature_importances_)
+        }
+
+    # Store model in memory
+    metadata = ModelMetadata(
+        model_id=model_id,
+        model_type=config.model_type,
+        threshold=metrics.threshold_analysis.threshold,
+        roc_auc=metrics.roc_auc,
+        accuracy=metrics.accuracy,
+        created_at=timestamp
+    )
+    store_model(model_id, model, metadata)
+
+    # Emit audit event
+    audit_event = TrainingAuditEvent(
+        event_id=f"evt_{uuid.uuid4().hex[:8]}",
+        model_id=model_id,
+        model_type=config.model_type,
+        training_config=config.model_dump(),
+        dataset_size=len(X),
+        test_accuracy=metrics.accuracy
+    )
+    emit_event(audit_event)
+
+    # Return training result
+    return TrainingResult(
+        model_id=model_id,
+        model_type=config.model_type,
+        metrics=metrics,
+        optimal_threshold=metrics.threshold_analysis.threshold,
+        feature_importance=feature_importance,
+        training_config=config
+    )

--- a/apps/api/services/training.py
+++ b/apps/api/services/training.py
@@ -20,7 +20,9 @@ from shared.schemas.audit import TrainingAuditEvent
 from shared.schemas.training import TrainingConfig, TrainingResult
 
 
-def load_dataset_from_csv(filepath: str) -> tuple[NDArray[np.float64], NDArray[np.int_]]:
+def load_dataset_from_csv(
+    filepath: str,
+) -> tuple[NDArray[np.float64], NDArray[np.int_]]:
     """Load dataset from CSV file.
 
     Args:
@@ -37,7 +39,9 @@ def load_dataset_from_csv(filepath: str) -> tuple[NDArray[np.float64], NDArray[n
 
     # Validate required columns exist
     if constants.TARGET_COLUMN not in df.columns:
-        raise ValueError(f"Target column '{constants.TARGET_COLUMN}' not found in dataset")
+        raise ValueError(
+            f"Target column '{constants.TARGET_COLUMN}' not found in dataset"
+        )
 
     missing_features = [f for f in constants.ALL_FEATURES if f not in df.columns]
     if missing_features:
@@ -50,7 +54,9 @@ def load_dataset_from_csv(filepath: str) -> tuple[NDArray[np.float64], NDArray[n
     return X, y
 
 
-def create_model(model_type: str) -> LogisticRegression | XGBClassifier | RandomForestClassifier:
+def create_model(
+    model_type: str,
+) -> LogisticRegression | XGBClassifier | RandomForestClassifier:
     """Create sklearn/xgboost model instance.
 
     Args:
@@ -72,7 +78,9 @@ def create_model(model_type: str) -> LogisticRegression | XGBClassifier | Random
         raise ValueError(f"Unknown model type: {model_type}")
 
 
-def train_model(config: TrainingConfig, dataset_path: str | None = None) -> TrainingResult:
+def train_model(
+    config: TrainingConfig, dataset_path: str | None = None
+) -> TrainingResult:
     """Train a credit risk model.
 
     Args:
@@ -98,7 +106,10 @@ def train_model(config: TrainingConfig, dataset_path: str | None = None) -> Trai
 
     # Load dataset
     if dataset_path is None:
-        dataset_path = constants.DEFAULT_DATASET_PATH if hasattr(constants, 'DEFAULT_DATASET_PATH') else "data/raw/cr_loan_w2.csv"
+        if hasattr(constants, 'DEFAULT_DATASET_PATH'):
+            dataset_path = constants.DEFAULT_DATASET_PATH
+        else:
+            dataset_path = "data/raw/cr_loan_w2.csv"
 
     X, y = load_dataset_from_csv(dataset_path)
 
@@ -131,7 +142,9 @@ def train_model(config: TrainingConfig, dataset_path: str | None = None) -> Trai
     if hasattr(model, "feature_importances_"):
         feature_importance = {
             feature: float(importance)
-            for feature, importance in zip(constants.ALL_FEATURES, model.feature_importances_)
+            for feature, importance in zip(
+                constants.ALL_FEATURES, model.feature_importances_
+            )
         }
 
     # Store model in memory

--- a/apps/api/services/training.py
+++ b/apps/api/services/training.py
@@ -12,8 +12,9 @@ from sklearn.model_selection import train_test_split
 from xgboost import XGBClassifier
 
 from apps.api.services.audit import emit_event
-from apps.api.services.model_store import ModelMetadata, store_model
+from apps.api.services.model_store import store_model
 from shared import constants
+from shared.schemas.model import ModelMetadata
 from shared.logic.evaluation import evaluate_model
 from shared.logic.preprocessing import undersample_majority_class
 from shared.schemas.audit import TrainingAuditEvent
@@ -106,10 +107,7 @@ def train_model(
 
     # Load dataset
     if dataset_path is None:
-        if hasattr(constants, 'DEFAULT_DATASET_PATH'):
-            dataset_path = constants.DEFAULT_DATASET_PATH
-        else:
-            dataset_path = "data/raw/cr_loan_w2.csv"
+        dataset_path = "data/processed/cr_loan_w2.csv"
 
     X, y = load_dataset_from_csv(dataset_path)
 

--- a/docs/RFCs/RFC-002-api-layer.md
+++ b/docs/RFCs/RFC-002-api-layer.md
@@ -1,0 +1,293 @@
+# RFC-002: FastAPI Service Layer
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Author(s) | [Your Name] |
+| Updated | 2025-01-31 |
+| Depends On | RFC-001 |
+
+## Objective
+
+Build FastAPI service in `apps/api/` that exposes training and prediction endpoints, consuming schemas and logic from `shared/`.
+
+**Goals:**
+
+- RESTful endpoints for train, predict, model management
+- Ephemeral training (session-scoped, returns metrics)
+- Optional model persistence with serve instructions
+- Structured logging and audit events
+- OpenAPI documentation auto-generated
+
+**Non-goals:**
+
+- Authentication (Phase 5)
+- Distributed model serving
+- WebSocket streaming
+
+## Motivation
+
+With `shared/` complete, we need an API layer so that:
+
+- Gradio and Next.js UIs can call a single backend
+- Marimo notebooks can optionally use API instead of direct logic calls
+- External systems can integrate via REST
+- Audit trail captures all operations
+
+## User Benefit
+
+**Release notes:** "Train and compare credit risk models via API. Get predictions programmatically."
+
+## Design Proposal
+
+### Directory Structure
+
+```
+apps/api/
+├── main.py                 # App factory, CORS, lifespan
+├── config.py               # Settings via pydantic-settings
+├── dependencies.py         # Request-scoped dependencies
+├── routers/
+│   ├── __init__.py
+│   ├── train.py            # POST /train
+│   ├── predict.py          # POST /predict
+│   └── models.py           # GET/POST /models
+├── services/
+│   ├── __init__.py
+│   ├── training.py         # Training orchestration
+│   ├── inference.py        # Prediction logic
+│   └── audit.py            # Audit event emission
+└── tests/
+    ├── conftest.py
+    ├── test_train.py
+    └── test_predict.py
+```
+
+### Endpoints
+
+| Method | Path | Request | Response | Description |
+|--------|------|---------|----------|-------------|
+| `POST` | `/train` | `TrainingConfig` + file | `TrainingResult` | Train model, return metrics |
+| `POST` | `/predict` | `PredictionRequest` | `PredictionResponse` | Run inference |
+| `GET` | `/models` | — | `list[ModelSummary]` | List session models |
+| `POST` | `/models/{id}/persist` | — | `PersistResponse` | Save artifact |
+| `GET` | `/health` | — | `{"status": "ok"}` | Health check |
+
+### Training Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant R as Router
+    participant S as Service
+    participant L as shared/logic
+    participant D as Data
+
+    C->>R: POST /train {config, file?}
+    R->>S: train_model(config, data)
+    S->>D: Load dataset
+    S->>L: preprocess(data)
+    S->>L: train sklearn/xgboost
+    S->>L: evaluate(model, test_data)
+    S->>L: find_optimal_threshold()
+    S->>S: emit AuditEvent
+    S-->>R: TrainingResult
+    R-->>C: 200 {metrics, threshold, model_id}
+```
+
+### Configuration
+
+```python
+# apps/api/config.py
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "Credit Risk API"
+    debug: bool = False
+    default_dataset_path: str = "data/raw/cr_loan_w2.csv"
+    model_artifacts_path: str = "artifacts/"
+    log_level: str = "INFO"
+
+    class Config:
+        env_prefix = "CREDIT_RISK_"
+```
+
+### Dependencies
+
+```python
+# apps/api/dependencies.py
+from functools import lru_cache
+from .config import Settings
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+```
+
+### Model Storage
+
+For Phase 2, models are stored in-memory per session:
+
+```python
+# In-memory store (replaced with persistence in Phase 5)
+_model_store: dict[str, Any] = {}
+
+def store_model(model_id: str, model: Any, metadata: dict) -> None:
+    _model_store[model_id] = {"model": model, "metadata": metadata}
+
+def get_model(model_id: str) -> Any:
+    return _model_store.get(model_id)
+```
+
+### Audit Logging
+
+```python
+# apps/api/services/audit.py
+import json
+import logging
+from shared.schemas.audit import AuditEvent
+
+logger = logging.getLogger("audit")
+
+def emit_event(event: AuditEvent) -> None:
+    logger.info(json.dumps(event.model_dump(), default=str))
+```
+
+## Alternatives Considered
+
+### Alternative 1: GraphQL
+
+**Pros:** Flexible queries, single endpoint
+
+**Cons:** Overkill for this use case, steeper learning curve
+
+**Why not chosen:** REST is simpler and sufficient for CRUD + train/predict
+
+### Alternative 2: gRPC
+
+**Pros:** Fast, typed contracts, streaming support
+
+**Cons:** Browser support requires proxy, harder to debug
+
+**Why not chosen:** REST better for web UIs and broader compatibility
+
+### Alternative 3: Serverless Functions
+
+**Pros:** Auto-scaling, pay-per-use
+
+**Cons:** Cold starts hurt training latency, complex local dev
+
+**Why not chosen:** Training requires warm instances; monolith simpler for now
+
+## Dependencies
+
+**New dependencies:**
+
+- `fastapi` — Web framework
+- `uvicorn` — ASGI server
+- `pydantic-settings` — Configuration management
+- `python-multipart` — File upload support
+
+**From shared/:**
+
+- All schemas from `shared/schemas/`
+- All logic from `shared/logic/`
+
+## Engineering Impact
+
+**Maintenance:** API layer owned by backend team
+
+**Testing:**
+
+- Integration tests using `TestClient`
+- Mock shared/logic for unit tests where needed
+- Target: 80%+ coverage on routers and services
+
+**Build impact:**
+
+- New `apps/api/` package
+- Add to uv workspace
+
+**API surface:**
+
+- Public REST API at `/train`, `/predict`, `/models`, `/health`
+- OpenAPI spec auto-generated at `/docs`
+
+## Platforms and Environments
+
+| Environment | Config | Notes |
+|-------------|--------|-------|
+| Local | `uv run uvicorn` | Hot reload enabled |
+| Docker | `Dockerfile` in apps/api/ | For deployment |
+| Production | Any cloud | Containerized |
+
+## Best Practices
+
+- All request/response models from `shared/schemas/`
+- Services contain business logic, routers are thin
+- Audit events for all mutating operations
+- Structured JSON logging
+
+## Tutorials and Examples
+
+After implementation:
+
+- OpenAPI docs at `/docs`
+- Example curl commands in README
+- Postman collection (optional)
+
+## User Impact
+
+**User-facing changes:**
+
+- New API available for programmatic access
+- Can train models without UI
+
+**Migration:**
+
+- No migration needed (new functionality)
+
+## Questions and Discussion Topics
+
+### 1. File uploads — multipart form or base64 in JSON body?
+
+**Decision: Multipart form upload.**
+
+- The training endpoint currently reads from a server-side CSV path (`settings.default_dataset_path`). When user-supplied datasets are needed, use `UploadFile` (multipart form) rather than base64 in JSON.
+- Multipart is the standard for file uploads in REST APIs — it streams data without inflating payload size (~33% overhead with base64), works natively with browser forms and `curl`, and FastAPI has first-class `UploadFile` support with automatic temp file handling.
+- Base64 would only make sense if datasets were always tiny and embedding them in JSON simplified a specific client. That's not the case here — credit risk CSVs can be tens of MB.
+- Implementation: add an optional `file: UploadFile | None` parameter to `POST /train`. When provided, write to a temp path and pass that to `train_model()`. When absent, fall back to `settings.default_dataset_path`. This is a backward-compatible change.
+
+### 2. Model storage — in-memory dict sufficient for Phase 2?
+
+**Decision: Yes, in-memory is sufficient for Phase 2. Migrate in Phase 5.**
+
+- The current `_model_store` dict in `model_store.py` is session-scoped and intentionally ephemeral. This is appropriate because Phase 2 is a demo/validation layer — models are trained, evaluated, and optionally persisted to disk via `POST /models/{id}/persist`.
+- The `persist` endpoint already handles durable storage (pickle + JSON metadata to `artifacts/`). Users who need to keep models across sessions use that endpoint.
+- Phase 5 should replace the in-memory store with a proper registry (filesystem index or MLflow) that supports loading previously persisted models at startup.
+- No changes needed now. The `model_store.py` comment already documents this plan.
+
+### 3. CORS origins — allow all (`*`) for dev, what for prod?
+
+**Decision: `*` for dev/demo (current). Explicit allowlist for any real deployment.**
+
+- Current `cors_origins: list[str] = ["*"]` in `config.py` is fine for local dev and internal demos where Gradio/Next.js frontends run on different ports.
+- For production or any internet-facing deployment, set `CREDIT_RISK_CORS_ORIGINS` environment variable to an explicit list (e.g., `["https://app.example.com", "https://demo.example.com"]`). The `pydantic-settings` env var binding already supports this — no code changes needed.
+- Do **not** ship `*` to production. A wide-open CORS policy allows any website to make authenticated requests on behalf of a user's browser session. Even without auth today, it's a bad habit to carry forward.
+- Phase 3 (when auth is added) should enforce this as a deployment check.
+
+### 4. Rate limiting — needed for public API?
+
+**Decision: Not needed for Phase 2. Add in Phase 3+ if the API becomes public.**
+
+- Phase 2 is internal/demo use only. The training endpoint is inherently slow (seconds to train sklearn models), which is a natural throttle. Adding rate limiting now would be premature complexity.
+- If the API becomes public-facing or is deployed behind a shared gateway, rate limiting should be added at the infrastructure level (e.g., API gateway, reverse proxy like nginx/Caddy) rather than in application code. This keeps the FastAPI layer focused on business logic.
+- If application-level limiting is needed later, `slowapi` (built on `limits`) integrates cleanly with FastAPI and can be added in a single middleware registration.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2025-01-31 | — | Initial draft |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
-
 [tool.poetry]
 name = "cookbook-data-viz-plotly"
 version = "0.0.1"

--- a/shared/logic/__init__.py
+++ b/shared/logic/__init__.py
@@ -15,6 +15,7 @@ from shared.logic.preprocessing import (
     encode_home_ownership,
     encode_loan_grade,
     encode_loan_intent,
+    loan_application_to_feature_vector,
     undersample_majority_class,
 )
 from shared.logic.threshold import evaluate_threshold, find_optimal_threshold
@@ -34,6 +35,7 @@ __all__ = [
     "encode_home_ownership",
     "encode_loan_grade",
     "encode_loan_intent",
+    "loan_application_to_feature_vector",
     "undersample_majority_class",
     # Threshold
     "evaluate_threshold",

--- a/shared/logic/evaluation.py
+++ b/shared/logic/evaluation.py
@@ -36,6 +36,9 @@ def calculate_roc_curve(
     """
     fpr, tpr, thresholds = roc_curve(y_true, y_proba)
 
+    # Replace inf values with finite values for JSON serialization
+    thresholds = np.where(np.isinf(thresholds), 1.0, thresholds)
+
     return ROCCurveData(
         fpr=fpr.tolist(), tpr=tpr.tolist(), thresholds=thresholds.tolist()
     )

--- a/shared/schemas/__init__.py
+++ b/shared/schemas/__init__.py
@@ -14,6 +14,7 @@ from shared.schemas.metrics import (
     ROCCurveData,
     ThresholdResult,
 )
+from shared.schemas.model import ModelMetadata, PersistResponse
 from shared.schemas.prediction import (
     PredictionRequest,
     PredictionResponse,
@@ -36,6 +37,9 @@ __all__ = [
     "ModelMetrics",
     "ROCCurveData",
     "ThresholdResult",
+    # Model
+    "ModelMetadata",
+    "PersistResponse",
     # Prediction
     "PredictionRequest",
     "PredictionResponse",

--- a/shared/schemas/model.py
+++ b/shared/schemas/model.py
@@ -1,0 +1,37 @@
+"""Schemas for model metadata and persistence."""
+
+from pydantic import BaseModel
+
+
+class ModelMetadata(BaseModel):
+    """Metadata for a stored model.
+
+    Attributes:
+        model_id: Unique identifier for the model.
+        model_type: Type of ML model (logistic_regression, xgboost, random_forest).
+        threshold: Optimal classification threshold.
+        roc_auc: Area under ROC curve.
+        accuracy: Test set accuracy.
+        created_at: Timestamp when model was trained.
+    """
+
+    model_id: str
+    model_type: str
+    threshold: float
+    roc_auc: float
+    accuracy: float
+    created_at: str
+
+
+class PersistResponse(BaseModel):
+    """Response from model persistence operation.
+
+    Attributes:
+        model_id: ID of the persisted model.
+        path: File path where model was saved.
+        instructions: Instructions for loading the model.
+    """
+
+    model_id: str
+    path: str
+    instructions: str

--- a/shared/schemas/training.py
+++ b/shared/schemas/training.py
@@ -1,11 +1,10 @@
 """Training configuration and result schemas."""
 
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from shared.schemas.metrics import ModelMetrics
+from shared.schemas.metrics import ModelMetrics
 
 
 class TrainingConfig(BaseModel):
@@ -46,7 +45,7 @@ class TrainingResult(BaseModel):
 
     model_id: str = Field(description="Unique model identifier")
     model_type: str = Field(description="Model type")
-    metrics: "ModelMetrics" = Field(description="Model performance metrics")
+    metrics: ModelMetrics = Field(description="Model performance metrics")
     optimal_threshold: float = Field(
         ge=0, le=1, description="Optimal classification threshold"
     )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -15,7 +15,7 @@ def test_settings() -> Settings:
     """Create test settings."""
     return Settings(
         debug=True,
-        default_dataset_path="data/raw/cr_loan_w2.csv",
+        default_dataset_path="data/processed/cr_loan_w2.csv",
         model_artifacts_path="test_artifacts/",
         log_level="DEBUG"
     )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,73 @@
+"""Pytest fixtures for API tests."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.config import Settings
+from apps.api.main import create_app
+from apps.api.services.model_store import clear_all_models
+from shared.schemas.loan import LoanApplication
+from shared.schemas.training import TrainingConfig
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    """Create test settings."""
+    return Settings(
+        debug=True,
+        default_dataset_path="data/raw/cr_loan_w2.csv",
+        model_artifacts_path="test_artifacts/",
+        log_level="DEBUG"
+    )
+
+
+@pytest.fixture
+def client(test_settings: Settings) -> TestClient:
+    """Create FastAPI test client.
+
+    Args:
+        test_settings: Test configuration settings.
+
+    Returns:
+        TestClient for making API requests.
+    """
+    app = create_app(settings=test_settings)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_models():
+    """Clear model store before each test."""
+    clear_all_models()
+    yield
+    clear_all_models()
+
+
+@pytest.fixture
+def sample_training_config() -> TrainingConfig:
+    """Create sample training configuration."""
+    return TrainingConfig(
+        model_type="logistic_regression",
+        test_size=0.2,
+        random_state=42,
+        undersample=False,
+        cv_folds=5
+    )
+
+
+@pytest.fixture
+def sample_loan_application() -> LoanApplication:
+    """Create sample loan application."""
+    return LoanApplication(
+        person_age=25,
+        person_income=50000.0,
+        person_emp_length=3.0,
+        loan_amnt=10000.0,
+        loan_int_rate=10.5,
+        loan_percent_income=0.2,
+        cb_person_cred_hist_length=5,
+        person_home_ownership="RENT",
+        loan_intent="EDUCATION",
+        loan_grade="B",
+        cb_person_default_on_file="N"
+    )

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,25 @@
+"""Tests for health check endpoint."""
+
+from fastapi.testclient import TestClient
+
+
+def test_health_check(client: TestClient):
+    """Test health check endpoint returns OK status."""
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "service" in data
+
+
+def test_health_check_structure(client: TestClient):
+    """Test health check response structure."""
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert "status" in data
+    assert "service" in data
+    assert data["status"] == "ok"

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,151 @@
+"""Tests for model management endpoints."""
+
+from fastapi.testclient import TestClient
+
+from shared.schemas.training import TrainingConfig
+
+
+def test_list_models_empty(client: TestClient):
+    """Test listing models when no models exist."""
+    response = client.get("/models/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+
+def test_list_models_after_training(
+    client: TestClient,
+    sample_training_config: TrainingConfig
+):
+    """Test listing models after training."""
+    # Train a model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    assert train_response.status_code == 200
+    model_id = train_response.json()["model_id"]
+
+    # List models
+    response = client.get("/models/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+
+    model_metadata = data[0]
+    assert model_metadata["model_id"] == model_id
+    assert "model_type" in model_metadata
+    assert "threshold" in model_metadata
+    assert "roc_auc" in model_metadata
+    assert "accuracy" in model_metadata
+    assert "created_at" in model_metadata
+
+
+def test_list_multiple_models(client: TestClient):
+    """Test listing multiple models."""
+    # Train multiple models
+    config1 = TrainingConfig(model_type="logistic_regression")
+    config2 = TrainingConfig(model_type="xgboost")
+
+    client.post("/train/", json=config1.model_dump())
+    client.post("/train/", json=config2.model_dump())
+
+    # List models
+    response = client.get("/models/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+    # Verify different model types
+    model_types = {model["model_type"] for model in data}
+    assert "logistic_regression" in model_types
+    assert "xgboost" in model_types
+
+
+def test_get_model_metadata_success(
+    client: TestClient,
+    sample_training_config: TrainingConfig
+):
+    """Test getting metadata for a specific model."""
+    # Train model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Get model metadata
+    response = client.get(f"/models/{model_id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["model_id"] == model_id
+    assert data["model_type"] == "logistic_regression"
+    assert 0 <= data["threshold"] <= 1
+    assert 0 <= data["roc_auc"] <= 1
+    assert 0 <= data["accuracy"] <= 1
+
+
+def test_get_model_metadata_not_found(client: TestClient):
+    """Test getting metadata for non-existent model."""
+    response = client.get("/models/nonexistent_model")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_persist_model_success(
+    client: TestClient,
+    sample_training_config: TrainingConfig
+):
+    """Test persisting a model to disk."""
+    # Train model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Persist model
+    response = client.post(f"/models/{model_id}/persist")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check response structure
+    assert "model_id" in data
+    assert "path" in data
+    assert "instructions" in data
+
+    assert data["model_id"] == model_id
+    assert model_id in data["path"]
+    assert ".pkl" in data["path"]
+    assert "pickle" in data["instructions"].lower()
+    assert "load" in data["instructions"].lower()
+
+
+def test_persist_model_not_found(client: TestClient):
+    """Test persisting a non-existent model."""
+    response = client.post("/models/nonexistent_model/persist")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_model_workflow_integration(client: TestClient):
+    """Test complete model workflow: train -> list -> get -> persist."""
+    # Step 1: Train model
+    config = TrainingConfig(model_type="xgboost")
+    train_response = client.post("/train/", json=config.model_dump())
+    assert train_response.status_code == 200
+    model_id = train_response.json()["model_id"]
+
+    # Step 2: List models
+    list_response = client.get("/models/")
+    assert list_response.status_code == 200
+    assert len(list_response.json()) == 1
+
+    # Step 3: Get specific model
+    get_response = client.get(f"/models/{model_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["model_id"] == model_id
+
+    # Step 4: Persist model
+    persist_response = client.post(f"/models/{model_id}/persist")
+    assert persist_response.status_code == 200
+    assert persist_response.json()["model_id"] == model_id

--- a/tests/api/test_predict.py
+++ b/tests/api/test_predict.py
@@ -1,0 +1,183 @@
+"""Tests for prediction endpoint."""
+
+from fastapi.testclient import TestClient
+
+from shared.schemas.loan import LoanApplication
+from shared.schemas.training import TrainingConfig
+
+
+def test_predict_success(
+    client: TestClient,
+    sample_training_config: TrainingConfig,
+    sample_loan_application: LoanApplication
+):
+    """Test successful prediction."""
+    # First train a model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    assert train_response.status_code == 200
+    model_id = train_response.json()["model_id"]
+
+    # Make prediction
+    prediction_request = {
+        "model_id": model_id,
+        "applications": [sample_loan_application.model_dump()],
+        "threshold": None,
+        "include_probabilities": True
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check required fields
+    assert "model_id" in data
+    assert "model_type" in data
+    assert "threshold" in data
+    assert "predictions" in data
+    assert "timestamp" in data
+    assert "total_applications" in data
+    assert "predicted_defaults" in data
+    assert "predicted_approvals" in data
+
+    # Verify predictions structure
+    predictions = data["predictions"]
+    assert len(predictions) == 1
+
+    prediction = predictions[0]
+    assert "application" in prediction
+    assert "predicted_default" in prediction
+    assert "default_probability" in prediction
+    assert "confidence" in prediction
+
+    # Verify probability and confidence are valid
+    assert 0 <= prediction["default_probability"] <= 1
+    assert 0 <= prediction["confidence"] <= 1
+
+
+def test_predict_multiple_applications(
+    client: TestClient,
+    sample_training_config: TrainingConfig
+):
+    """Test prediction with multiple loan applications."""
+    # Train model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Create multiple applications
+    applications = [
+        LoanApplication(
+            person_age=25,
+            person_income=50000.0,
+            person_emp_length=3.0,
+            loan_amnt=10000.0,
+            loan_int_rate=10.5,
+            loan_percent_income=0.2,
+            cb_person_cred_hist_length=5,
+            person_home_ownership="RENT",
+            loan_intent="EDUCATION",
+            loan_grade="B",
+            cb_person_default_on_file="N"
+        ),
+        LoanApplication(
+            person_age=35,
+            person_income=75000.0,
+            person_emp_length=10.0,
+            loan_amnt=20000.0,
+            loan_int_rate=8.0,
+            loan_percent_income=0.27,
+            cb_person_cred_hist_length=12,
+            person_home_ownership="OWN",
+            loan_intent="HOMEIMPROVEMENT",
+            loan_grade="A",
+            cb_person_default_on_file="N"
+        )
+    ]
+
+    prediction_request = {
+        "model_id": model_id,
+        "applications": [app.model_dump() for app in applications]
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["predictions"]) == 2
+    assert data["total_applications"] == 2
+
+
+def test_predict_custom_threshold(
+    client: TestClient,
+    sample_training_config: TrainingConfig,
+    sample_loan_application: LoanApplication
+):
+    """Test prediction with custom threshold."""
+    # Train model
+    train_response = client.post("/train/", json=sample_training_config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Predict with custom threshold
+    prediction_request = {
+        "model_id": model_id,
+        "applications": [sample_loan_application.model_dump()],
+        "threshold": 0.7  # Custom threshold
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["threshold"] == 0.7
+
+
+def test_predict_model_not_found(
+    client: TestClient,
+    sample_loan_application: LoanApplication
+):
+    """Test prediction with non-existent model."""
+    prediction_request = {
+        "model_id": "nonexistent_model",
+        "applications": [sample_loan_application.model_dump()]
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_predict_invalid_application(client: TestClient):
+    """Test prediction with invalid loan application."""
+    # Train model
+    config = TrainingConfig(model_type="logistic_regression")
+    train_response = client.post("/train/", json=config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Invalid application (missing required fields)
+    prediction_request = {
+        "model_id": model_id,
+        "applications": [
+            {
+                "person_age": 25,
+                "person_income": 50000.0
+                # Missing other required fields
+            }
+        ]
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 422  # Validation error
+
+
+def test_predict_empty_applications(client: TestClient):
+    """Test prediction with empty applications list."""
+    # Train model
+    config = TrainingConfig(model_type="logistic_regression")
+    train_response = client.post("/train/", json=config.model_dump())
+    model_id = train_response.json()["model_id"]
+
+    # Empty applications list
+    prediction_request = {
+        "model_id": model_id,
+        "applications": []
+    }
+    response = client.post("/predict/", json=prediction_request)
+
+    assert response.status_code == 422  # Validation error

--- a/tests/api/test_train.py
+++ b/tests/api/test_train.py
@@ -1,0 +1,114 @@
+"""Tests for training endpoint."""
+
+from fastapi.testclient import TestClient
+
+from shared.schemas.training import TrainingConfig
+
+
+def test_train_model_success(client: TestClient, sample_training_config: TrainingConfig):
+    """Test successful model training."""
+    response = client.post("/train/", json=sample_training_config.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check required fields
+    assert "model_id" in data
+    assert "model_type" in data
+    assert "metrics" in data
+    assert "optimal_threshold" in data
+    assert "training_config" in data
+
+    # Verify model type
+    assert data["model_type"] == "logistic_regression"
+
+    # Verify metrics structure
+    metrics = data["metrics"]
+    assert "accuracy" in metrics
+    assert "precision" in metrics
+    assert "recall" in metrics
+    assert "f1_score" in metrics
+    assert "roc_auc" in metrics
+    assert "threshold_analysis" in metrics
+
+    # Verify threshold is valid
+    threshold = data["optimal_threshold"]
+    assert 0 <= threshold <= 1
+
+
+def test_train_xgboost_model(client: TestClient):
+    """Test training XGBoost model."""
+    config = TrainingConfig(model_type="xgboost")
+    response = client.post("/train/", json=config.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["model_type"] == "xgboost"
+    assert "feature_importance" in data
+    assert data["feature_importance"] is not None
+
+
+def test_train_random_forest_model(client: TestClient):
+    """Test training Random Forest model."""
+    config = TrainingConfig(model_type="random_forest")
+    response = client.post("/train/", json=config.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["model_type"] == "random_forest"
+    assert "feature_importance" in data
+
+
+def test_train_with_undersampling(client: TestClient):
+    """Test training with undersampling enabled."""
+    config = TrainingConfig(
+        model_type="logistic_regression",
+        undersample=True
+    )
+    response = client.post("/train/", json=config.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["training_config"]["undersample"] is True
+
+
+def test_train_invalid_model_type(client: TestClient):
+    """Test training with invalid model type."""
+    invalid_config = {
+        "model_type": "invalid_model",
+        "test_size": 0.2,
+        "random_state": 42
+    }
+    response = client.post("/train/", json=invalid_config)
+
+    assert response.status_code == 422  # Validation error
+
+
+def test_train_invalid_test_size(client: TestClient):
+    """Test training with invalid test size."""
+    invalid_config = {
+        "model_type": "logistic_regression",
+        "test_size": 0.9,  # Too large
+        "random_state": 42
+    }
+    response = client.post("/train/", json=invalid_config)
+
+    assert response.status_code == 422  # Validation error
+
+
+def test_multiple_models_training(client: TestClient):
+    """Test training multiple models in sequence."""
+    config1 = TrainingConfig(model_type="logistic_regression")
+    config2 = TrainingConfig(model_type="xgboost")
+
+    response1 = client.post("/train/", json=config1.model_dump())
+    response2 = client.post("/train/", json=config2.model_dump())
+
+    assert response1.status_code == 200
+    assert response2.status_code == 200
+
+    model_id1 = response1.json()["model_id"]
+    model_id2 = response2.json()["model_id"]
+
+    # Ensure different model IDs
+    assert model_id1 != model_id2


### PR DESCRIPTION
## Summary

- **Critical fix**: Remove duplicated categorical encoding maps from `inference.py` — now imports `loan_application_to_feature_vector` from `shared/logic/preprocessing`, which derives one-hot encoding from `constants.CATEGORICAL_FEATURES_ENCODED` column names. Previously, if column order changed, predictions would silently produce wrong feature vectors.
- **Schema consolidation**: Extract `ModelMetadata` and `PersistResponse` from API layer into `shared/schemas/model.py` per RFC-001 ("all Pydantic schemas in shared/").
- **Error handling**: Routers now log full tracebacks server-side and return generic "Internal server error" to clients instead of leaking internal details.
- **Dead code removal**: Remove unreachable `hasattr(constants, 'DEFAULT_DATASET_PATH')` fallback in training service.
- **Build fix**: Remove duplicate `[build-system]` section in `pyproject.toml` that blocked pytest.
- **RFC decisions**: Answer all open questions in RFC-001 (5) and RFC-002 (4) with rationale.

## Test plan

- [x] All 82 shared tests pass
- [x] All 23 API integration tests pass
- [x] Ruff linting clean
- [x] Verify prediction output matches previous behavior with a manual `/predict` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)