### PR TITLE
fix(web): phase 5 review fixes — validation, compare toggle, RFC decisions

### DIFF
--- a/apps/api/services/training.py
+++ b/apps/api/services/training.py
@@ -154,7 +154,19 @@ def train_model(
         accuracy=metrics.accuracy,
         created_at=timestamp,
     )
-    store_model(model_id, model, metadata)
+
+    # Build training result
+    training_result = TrainingResult(
+        model_id=model_id,
+        model_type=config.model_type,
+        metrics=metrics,
+        optimal_threshold=metrics.threshold_analysis.threshold,
+        feature_importance=feature_importance,
+        training_config=config,
+        training_time_seconds=round(training_time_seconds, 3),
+    )
+
+    store_model(model_id, model, metadata, training_result=training_result)
 
     # Emit audit event
     audit_event = TrainingAuditEvent(
@@ -167,13 +179,4 @@ def train_model(
     )
     emit_event(audit_event)
 
-    # Return training result
-    return TrainingResult(
-        model_id=model_id,
-        model_type=config.model_type,
-        metrics=metrics,
-        optimal_threshold=metrics.threshold_analysis.threshold,
-        feature_importance=feature_importance,
-        training_config=config,
-        training_time_seconds=round(training_time_seconds, 3),
-    )
+    return training_result

--- a/apps/web/components/forms/loan-fields.tsx
+++ b/apps/web/components/forms/loan-fields.tsx
@@ -56,7 +56,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 			<Input
 				label="Annual Income"
 				type="number"
-				min={0}
+				min={1}
 				step={1000}
 				value={values.person_income}
 				onChange={(e) => onChange("person_income", Number(e.target.value))}
@@ -74,7 +74,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 			<Input
 				label="Loan Amount"
 				type="number"
-				min={0}
+				min={1}
 				step={500}
 				value={values.loan_amnt}
 				onChange={(e) => onChange("loan_amnt", Number(e.target.value))}
@@ -83,7 +83,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 			<Input
 				label="Interest Rate (%)"
 				type="number"
-				min={0}
+				min={0.01}
 				max={100}
 				step={0.01}
 				value={values.loan_int_rate}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -85,6 +85,10 @@ export const api = {
 		return request<ModelMetadata>(`/models/${modelId}`);
 	},
 
+	getModelResults: async (modelId: string): Promise<TrainingResult> => {
+		return request<TrainingResult>(`/models/${modelId}/results`);
+	},
+
 	persistModel: async (modelId: string): Promise<PersistResponse> => {
 		return request<PersistResponse>(`/models/${modelId}/persist`, {
 			method: "POST",

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -130,8 +130,6 @@ export interface ModelMetadata {
 	created_at: string;
 }
 
-export interface ModelSummary extends ModelMetadata {}
-
 // === API response types ===
 
 export interface HealthResponse {

--- a/apps/web/lib/validation.ts
+++ b/apps/web/lib/validation.ts
@@ -1,0 +1,52 @@
+/**
+ * Client-side validation matching Pydantic constraints in shared/schemas/loan.py.
+ */
+
+import type { LoanApplication } from "./types";
+
+type ValidationErrors = Partial<Record<keyof LoanApplication, string>>;
+
+/**
+ * Validate a loan application against Pydantic schema constraints.
+ * Returns an object with field-level error messages (empty if valid).
+ */
+export function validateLoanApplication(app: LoanApplication): ValidationErrors {
+	const errors: ValidationErrors = {};
+
+	// person_age: int, ge=18, le=120
+	if (!Number.isInteger(app.person_age) || app.person_age < 18 || app.person_age > 120) {
+		errors.person_age = "Age must be a whole number between 18 and 120";
+	}
+
+	// person_income: float, gt=0
+	if (app.person_income <= 0) {
+		errors.person_income = "Income must be greater than 0";
+	}
+
+	// person_emp_length: float, ge=0
+	if (app.person_emp_length < 0) {
+		errors.person_emp_length = "Employment length cannot be negative";
+	}
+
+	// loan_amnt: float, gt=0
+	if (app.loan_amnt <= 0) {
+		errors.loan_amnt = "Loan amount must be greater than 0";
+	}
+
+	// loan_int_rate: float, gt=0, le=100
+	if (app.loan_int_rate <= 0 || app.loan_int_rate > 100) {
+		errors.loan_int_rate = "Interest rate must be between 0 (exclusive) and 100";
+	}
+
+	// loan_percent_income: float, ge=0, le=1
+	if (app.loan_percent_income < 0 || app.loan_percent_income > 1) {
+		errors.loan_percent_income = "Loan % of income must be between 0 and 1";
+	}
+
+	// cb_person_cred_hist_length: int, ge=0
+	if (!Number.isInteger(app.cb_person_cred_hist_length) || app.cb_person_cred_hist_length < 0) {
+		errors.cb_person_cred_hist_length = "Credit history length must be a non-negative whole number";
+	}
+
+	return errors;
+}

--- a/docs/0-RFCs/RFC-005-nextjs-ui.md
+++ b/docs/0-RFCs/RFC-005-nextjs-ui.md
@@ -431,13 +431,24 @@ NEXT_PUBLIC_API_URL=https://api.your-domain.com
 - **Error boundaries** — Graceful error handling
 - **Accessible** — ARIA labels, keyboard navigation
 
-## Questions and Discussion Topics
+## Questions and Discussion Topics (Resolved)
 
-1. **Component library** — shadcn/ui, Radix, or custom?
-2. **Data fetching** — Plain fetch, SWR, or React Query?
-3. **Form library** — react-hook-form + zod, or Formik?
-4. **Charts** — Recharts, Nivo, or Plotly.js?
-5. **State management** — React context, Zustand, or none?
+1. **Component library** — **Decision: Custom Tailwind components.** Keeps the dependency footprint minimal. Revisit shadcn/ui if component count grows significantly.
+2. **Data fetching** — **Decision: Plain fetch with typed wrapper (`lib/api-client.ts`).** Native AbortController handles timeouts. Add SWR/React Query if caching or automatic refetching becomes needed.
+3. **Form library** — **Decision: Controlled components with manual validation (`lib/validation.ts`).** Validation mirrors Pydantic constraints from `shared/schemas/loan.py`. Keeps bundle size small; consider react-hook-form + zod if form complexity grows.
+4. **Charts** — **Decision: Recharts 3.7.0.** React-native, good TypeScript support, lightweight. Handles all four chart types (ROC, calibration, confusion matrix, metrics bar).
+5. **State management** — **Decision: Local state only (useState).** No shared cross-page state exists. Add Zustand or React context only when a concrete need arises.
+
+### Deferred Scope
+
+The following RFC-specified items were intentionally deferred from the initial implementation:
+
+- `hooks/` directory (use-train, use-predict, use-models) — state is managed inline in pages
+- `lib/utils.ts` helper module — no utility functions needed yet
+- `app/api/health/route.ts` proxy endpoint — client calls API directly
+- Export CSV button on Compare page
+- Dataset upload option on Train page
+- Training history list on Train page
 
 ---
 
@@ -446,3 +457,4 @@ NEXT_PUBLIC_API_URL=https://api.your-domain.com
 | Date | Author | Changes |
 |------|--------|---------|
 | 2025-01-31 | — | Initial draft |
+| 2026-02-02 | — | Resolved open questions, documented deferred scope |


### PR DESCRIPTION
## Summary

- **Store full training results in API** — `model_store` now preserves `TrainingResult` alongside the model, with a new `GET /models/{id}/results` endpoint to retrieve it
- **Compare page toggle** — Users can choose between fetching stored results (default) or re-training models; shows training timestamps and warns when stored results are unavailable
- **Client-side validation** — `validateLoanApplication()` mirrors Pydantic `gt`/`ge`/`le` constraints with per-field error messages; fixed HTML `min` attributes for `person_income`, `loan_amnt`, `loan_int_rate`
- **Dead code removal** — Removed unused `ModelSummary` type alias
- **RFC-005 updated** — Resolved all 5 open questions with decisions and documented deferred scope items

## Test plan

- [x] `npm run build` in `apps/web/` — passes (no type errors)
- [x] `npm run lint` in `apps/web/` — passes (biome check clean)
- [x] `python -m pytest tests/` — 105 passed (82 shared + 23 API)
- [ ] Manual: train a model, navigate to Compare, verify "Stored Results" toggle fetches without re-training
- [ ] Manual: submit prediction form with invalid values (income=0, rate=0), verify per-field errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)