### PR TITLE
feat(ci): add coverage reporting and security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check .
 
-      - name: Run tests
-        run: uv run pytest -v
+      - name: Run tests with coverage
+        run: uv run pytest -v --cov=shared --cov=apps --cov-report=xml --cov-report=term
 
   web-lint-build:
     name: Web Lint & Build
@@ -56,3 +56,29 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra api --extra dev
+
+      - name: Bandit security lint
+        run: uv run bandit -r shared/ apps/
+
+      - name: Pip audit
+        run: uv run pip-audit
+
+      - name: Dependency check
+        run: uv run deptry .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ api = [
 ]
 dev = [
     "pytest>=8.3",
+    "pytest-cov>=6.0",
     "ruff>=0.8",
 ]
 


### PR DESCRIPTION
## Summary
- Add `pytest-cov` to dev dependencies
- Update pytest step to report coverage (`--cov=shared --cov=apps`, xml + terminal output)
- Add new blocking **Security Scan** job with:
  - **bandit** — static analysis for Python security issues
  - **pip-audit** — checks packages against known CVE databases
  - **deptry** — catches missing or unused dependencies

All three CI jobs (python-lint-test, web-lint-build, security) run in parallel.

`coverage.xml` was already in `.gitignore`.

## Test plan
- [ ] Verify `python-lint-test` job passes with coverage output visible in logs
- [ ] Verify `security` job passes (bandit + pip-audit + deptry)
- [ ] Verify `web-lint-build` job still passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)