### PR TITLE
fix(ci): configure deptry for monorepo structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,18 @@ packages = ["shared", "apps"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.deptry]
+# apps/ and shared/ are local packages, not external dependencies
+ignore_modules = ["apps", "shared"]
+
+[tool.deptry.per_rule_ignores]
+# CLI tools are invoked, not imported
+DEP002 = ["uvicorn", "pytest", "pytest-cov", "ruff", "bandit", "deptry", "pip-audit"]
+# Gradio app has its own requirements.txt (deploys separately to HF Spaces)
+DEP001 = ["gradio"]
+# httpx is a dev dep for test client; Gradio installs it via its own requirements.txt
+DEP004 = ["httpx"]
+
 [dependency-groups]
 dev = [
     "bandit>=1.9.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,15 +54,13 @@ packages = ["shared", "apps"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.deptry]
-# apps/ and shared/ are local packages, not external dependencies
-ignore_modules = ["apps", "shared"]
-
 [tool.deptry.per_rule_ignores]
 # CLI tools are invoked, not imported
 DEP002 = ["uvicorn", "pytest", "pytest-cov", "ruff", "bandit", "deptry", "pip-audit"]
 # Gradio app has its own requirements.txt (deploys separately to HF Spaces)
 DEP001 = ["gradio"]
+# apps/ and shared/ are local packages, not external transitive deps
+DEP003 = ["apps", "shared"]
 # httpx is a dev dep for test client; Gradio installs it via its own requirements.txt
 DEP004 = ["httpx"]
 


### PR DESCRIPTION
## Summary
- Add `[tool.deptry]` config to `pyproject.toml` to suppress 44 false positives
- `apps/` and `shared/` are local packages, not external transitive deps (DEP003)
- CLI tools like pytest, ruff, bandit are invoked not imported (DEP002)
- Gradio manages its own deps via `requirements.txt` (DEP001, DEP004)

Fixes the failing security job from PR #24.

## Test plan
- [ ] Verify `security` CI job passes (deptry reports 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)