### PR TITLE
feat(ci): monorepo-aware Gradio deploy to HF Spaces

### DIFF
--- a/.github/workflows/sync_to_hf_hub.yml
+++ b/.github/workflows/sync_to_hf_hub.yml
@@ -1,20 +1,68 @@
-name: Sync to Hugging Face hub
+name: Deploy Gradio to HF Spaces
+
 on:
   push:
     branches: [main]
-
-  # to run this workflow manually from the Actions tab
+    paths: [apps/gradio/**]
   workflow_dispatch:
 
 jobs:
-  sync-to-hub:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          fetch-depth: 0
-          lfs: true
-      - name: Push to hub
+          python-version: "3.12"
+
+      # Create Space (if it doesn't exist) and set secrets via HF API
+      - name: Setup HF Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://pkiage:$HF_TOKEN@huggingface.co/spaces/pkiage/credit_risk_modeling_demo main
+          CREDIT_RISK_API_URL: ${{ secrets.CREDIT_RISK_API_URL }}
+        run: |
+          pip install huggingface_hub
+          python << 'SETUP'
+          import os
+          from huggingface_hub import HfApi
+
+          token = os.environ["HF_TOKEN"]
+          api_url = os.environ["CREDIT_RISK_API_URL"]
+
+          api = HfApi(token=token)
+          api.create_repo(
+              "pkiage/credit_risk_modeling_demo",
+              repo_type="space",
+              space_sdk="gradio",
+              exist_ok=True,
+          )
+          api.add_space_secret(
+              "pkiage/credit_risk_modeling_demo",
+              "CREDIT_RISK_API_URL",
+              api_url,
+          )
+          print("HF Space ready with CREDIT_RISK_API_URL secret set")
+          SETUP
+
+      # Copy apps/gradio/* and rewrite monorepo imports for flat layout
+      - name: Prepare deployment
+        run: |
+          mkdir -p /tmp/hf-deploy
+          cp -r apps/gradio/* /tmp/hf-deploy/
+          cd /tmp/hf-deploy
+          sed -i 's/from apps\.gradio\./from /g' app.py
+          sed -i 's/from apps\.gradio\./from /g' components/*.py
+
+      # Push to HF Spaces
+      - name: Deploy to HF Spaces
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          cd /tmp/hf-deploy
+          git init
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+          git commit -m "Deploy from ${{ github.sha }}"
+          git push --force https://pkiage:$HF_TOKEN@huggingface.co/spaces/pkiage/credit_risk_modeling_demo main


### PR DESCRIPTION
## Summary

- Replaces the old `sync_to_hf_hub.yml` that pushed the entire repo (broken for monorepo layout)
- New workflow extracts `apps/gradio/` to a flat directory, rewrites `apps.gradio.*` imports, and pushes to HF Spaces
- Creates the HF Space programmatically via `huggingface_hub` API if it doesn't exist
- Sets `CREDIT_RISK_API_URL` secret on the Space automatically
- Only triggers on `apps/gradio/**` changes + manual `workflow_dispatch`

## Setup required

Add two GitHub secrets (Settings → Secrets → Actions):

| Secret | Value |
|--------|-------|
| `HF_TOKEN` | HuggingFace write token |
| `CREDIT_RISK_API_URL` | `https://credit-risk-api-wo5h.onrender.com` |

## Test plan

- [ ] Verify `HF_TOKEN` and `CREDIT_RISK_API_URL` secrets are set in GitHub
- [ ] Merge PR, then trigger workflow manually from Actions tab
- [ ] Confirm HF Space is created at https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo
- [ ] Verify Gradio app loads and can reach the API
- [ ] Test Train, Predict, and Compare tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)