### PR TITLE
fix(gradio): add python_version and live demo link to HF Spaces README

### DIFF
--- a/apps/gradio/README.md
+++ b/apps/gradio/README.md
@@ -5,6 +5,7 @@ colorFrom: blue
 colorTo: green
 sdk: gradio
 sdk_version: 4.0.0
+python_version: "3.12"
 app_file: app.py
 pinned: false
 ---
@@ -12,6 +13,8 @@ pinned: false
 # Credit Risk Model Demo
 
 Interactive demo for training and evaluating credit risk models.
+
+**Live demo:** [huggingface.co/spaces/pkiage/credit_risk_modeling_demo](https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo)
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

- Add `python_version: "3.12"` to HF Spaces frontmatter (recommended by HF config template)
- Add link to deployed Space in README for discoverability

## Why

The HF Space at https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo shows "Missing configuration in README" because the deploy workflow (PR #26) hasn't triggered yet. Merging this PR touches `apps/gradio/**`, which will auto-trigger the deploy workflow and push the corrected README to the Space.

## Prerequisites

Before merging, ensure these GitHub secrets are set (Settings → Secrets → Actions):
- `HF_TOKEN` — HuggingFace write token
- `CREDIT_RISK_API_URL` — `https://credit-risk-api-wo5h.onrender.com`

## Test plan

- [ ] Verify GitHub secrets `HF_TOKEN` and `CREDIT_RISK_API_URL` are configured
- [ ] Merge PR → confirm "Deploy Gradio to HF Spaces" workflow triggers automatically
- [ ] Visit https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo — config error should be gone
- [ ] Test Train, Predict, and Compare tabs in the deployed Space

🤖 Generated with [Claude Code](https://claude.com/claude-code)