### PR TITLE
fix(ci): use git init -b main for HF Spaces deploy

### DIFF
--- a/.github/workflows/sync_to_hf_hub.yml
+++ b/.github/workflows/sync_to_hf_hub.yml
@@ -60,7 +60,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           cd /tmp/hf-deploy
-          git init
+          git init -b main
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .


### PR DESCRIPTION
## Summary

- Fix `error: src refspec main does not match any` in HF Spaces deploy workflow
- `git init` defaults to `master` branch; changed to `git init -b main` to match the push target

## Test plan

- [ ] Merge PR → workflow auto-triggers (touches workflow file, but also manually trigger if needed)
- [ ] Confirm "Deploy to HF Spaces" step succeeds
- [ ] Verify Space loads at https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)