### PR TITLE
fix(gradio): bump Gradio from 4.0.0 to 6.5.1

### DIFF
--- a/apps/gradio/README.md
+++ b/apps/gradio/README.md
@@ -4,7 +4,7 @@ emoji: "\U0001F4CA"
 colorFrom: blue
 colorTo: green
 sdk: gradio
-sdk_version: 4.0.0
+sdk_version: 6.5.1
 python_version: "3.12"
 app_file: app.py
 pinned: false

--- a/apps/gradio/requirements.txt
+++ b/apps/gradio/requirements.txt
@@ -1,3 +1,3 @@
-gradio>=4.0.0
+gradio>=6.5.1
 httpx>=0.25.0
 plotly>=5.0.0


### PR DESCRIPTION
## Summary

- Bump `gradio` from `>=4.0.0` to `>=6.5.1` in `requirements.txt` and HF Spaces `sdk_version`
- Gradio 4.0.0 imports `distutils` which was removed in Python 3.12, causing `ModuleNotFoundError` on HF Spaces

## Test plan

- [ ] Merge PR → deploy workflow auto-triggers (touches `apps/gradio/**`)
- [ ] Confirm Space loads without `distutils` error
- [ ] Test Train, Predict, and Compare tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)