### PR TITLE
feat(training): add feature selection and importance visualization

### DIFF
--- a/apps/api/services/model_store.py
+++ b/apps/api/services/model_store.py
@@ -31,6 +31,7 @@ def store_model(
     model: Any,
     metadata: ModelMetadata,
     training_result: TrainingResult | None = None,
+    feature_columns: list[str] | None = None,
 ) -> None:
     """Store a trained model in memory.
 
@@ -39,6 +40,8 @@ def store_model(
         model: Trained model object (sklearn/xgboost).
         metadata: Model metadata.
         training_result: Full training result with metrics (optional).
+        feature_columns: Ordered list of encoded column names the model was
+            trained on. Required for prediction-time feature subsetting.
 
     Example:
         >>> from sklearn.linear_model import LogisticRegression
@@ -56,6 +59,7 @@ def store_model(
         "model": model,
         "metadata": metadata.model_dump(),
         "training_result": training_result.model_dump() if training_result else None,
+        "feature_columns": feature_columns,
     }
 
 
@@ -112,6 +116,21 @@ def get_training_result(model_id: str) -> TrainingResult | None:
         return None
 
     return TrainingResult(**stored_data["training_result"])
+
+
+def get_feature_columns(model_id: str) -> list[str] | None:
+    """Retrieve the feature columns a model was trained on.
+
+    Args:
+        model_id: Model identifier.
+
+    Returns:
+        List of encoded column names, or None if model not found.
+    """
+    stored_data = _model_store.get(model_id)
+    if stored_data is None:
+        return None
+    return stored_data.get("feature_columns")
 
 
 def delete_model(model_id: str) -> bool:

--- a/apps/api/services/training.py
+++ b/apps/api/services/training.py
@@ -165,8 +165,7 @@ def train_model(
         # Linear models (Logistic Regression) — use absolute coefficients
         coefficients = np.abs(model.coef_[0])
         feature_importance = {
-            feature: float(coef)
-            for feature, coef in zip(feature_cols, coefficients)
+            feature: float(coef) for feature, coef in zip(feature_cols, coefficients)
         }
 
     # Store model in memory

--- a/apps/gradio/components/training_tab.py
+++ b/apps/gradio/components/training_tab.py
@@ -146,9 +146,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
             gr.Markdown("### Feature Selection")
 
             # Numeric features — each maps to a single encoded column
-            numeric_choices = [
-                (FEATURE_GROUP_LABELS[f], f) for f in NUMERIC_FEATURES
-            ]
+            numeric_choices = [(FEATURE_GROUP_LABELS[f], f) for f in NUMERIC_FEATURES]
             numeric_group = gr.CheckboxGroup(
                 choices=numeric_choices,
                 value=list(NUMERIC_FEATURES),
@@ -163,9 +161,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
             for cat_name in CATEGORICAL_FEATURES:
                 label = FEATURE_GROUP_LABELS[cat_name]
                 columns = FEATURE_GROUPS[cat_name]
-                col_choices = [
-                    (_column_display_name(c, cat_name), c) for c in columns
-                ]
+                col_choices = [(_column_display_name(c, cat_name), c) for c in columns]
                 with gr.Accordion(label, open=False):
                     select_all = gr.Checkbox(value=True, label="Select All")
                     col_group = gr.CheckboxGroup(
@@ -185,18 +181,12 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 label="Model Metrics",
                 interactive=False,
             )
-            threshold_display = gr.Textbox(
-                label="Optimal Threshold", interactive=False
-            )
-            training_time_display = gr.Textbox(
-                label="Training Time", interactive=False
-            )
+            threshold_display = gr.Textbox(label="Optimal Threshold", interactive=False)
+            training_time_display = gr.Textbox(label="Training Time", interactive=False)
             model_id_display = gr.Textbox(label="Model ID", interactive=False)
             roc_plot = gr.Plot(label="ROC Curve")
             importance_plot = gr.Plot(label="Feature Importance")
-            error_display = gr.Textbox(
-                label="Status", interactive=False, visible=False
-            )
+            error_display = gr.Textbox(label="Status", interactive=False, visible=False)
 
     # Wire up Select All ↔ column toggle events for each categorical group.
     # Uses .input() for Select All to avoid event loops: .input() fires only
@@ -210,9 +200,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
             """Check or uncheck all columns when Select All is toggled."""
             return cols if checked else []
 
-        def _sync_select_all(
-            selected: list[str], cols: list[str] = all_cols
-        ) -> bool:
+        def _sync_select_all(selected: list[str], cols: list[str] = all_cols) -> bool:
             """Update Select All checkbox to reflect column selection state."""
             return len(selected) == len(cols)
 
@@ -287,9 +275,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
 
         # Send None when all features are selected (backward compatible)
         features_param = (
-            selected_features
-            if len(selected_features) < len(ALL_FEATURES)
-            else None
+            selected_features if len(selected_features) < len(ALL_FEATURES) else None
         )
 
         try:
@@ -313,15 +299,11 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
 
             roc_fig = None
             if "roc_curve" in metrics:
-                roc_fig = _build_roc_plot(
-                    metrics["roc_curve"], selected_model_type
-                )
+                roc_fig = _build_roc_plot(metrics["roc_curve"], selected_model_type)
 
             importance_fig = None
             if result.get("feature_importance"):
-                importance_fig = _build_importance_plot(
-                    result["feature_importance"]
-                )
+                importance_fig = _build_importance_plot(result["feature_importance"])
 
             return (
                 table_data,

--- a/apps/gradio/components/training_tab.py
+++ b/apps/gradio/components/training_tab.py
@@ -8,6 +8,13 @@ import plotly.graph_objects as go
 
 import gradio as gr
 from apps.gradio.api_client import CreditRiskAPI
+from shared.constants import (
+    ALL_FEATURES,
+    CATEGORICAL_FEATURES,
+    FEATURE_GROUP_LABELS,
+    FEATURE_GROUPS,
+    NUMERIC_FEATURES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +57,38 @@ def _build_roc_plot(roc_data: dict[str, Any], model_type: str) -> go.Figure:
     return fig
 
 
+def _build_importance_plot(feature_importance: dict[str, float]) -> go.Figure:
+    """Build a horizontal bar chart of feature importance.
+
+    Args:
+        feature_importance: Mapping of feature name to importance score.
+
+    Returns:
+        Plotly Figure with horizontal bars sorted by importance.
+    """
+    sorted_items = sorted(feature_importance.items(), key=lambda x: abs(x[1]))
+    names = [item[0] for item in sorted_items]
+    values = [item[1] for item in sorted_items]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            x=values,
+            y=names,
+            orientation="h",
+            marker_color="#636EFA",
+        )
+    )
+    fig.update_layout(
+        title="Feature Importance",
+        xaxis_title="Importance",
+        height=max(400, len(names) * 25),
+        width=600,
+        margin={"l": 200},
+    )
+    return fig
+
+
 def _format_metrics_table(metrics: dict[str, Any]) -> list[list[str]]:
     """Format model metrics into a table rows list.
 
@@ -68,6 +107,20 @@ def _format_metrics_table(metrics: dict[str, Any]) -> list[list[str]]:
     ]
 
 
+def _column_display_name(col: str, group: str) -> str:
+    """Extract the human-readable suffix from a one-hot encoded column name.
+
+    Args:
+        col: Full encoded column name (e.g. "person_home_ownership_RENT").
+        group: Feature group name (e.g. "person_home_ownership").
+
+    Returns:
+        Suffix portion of the column name (e.g. "RENT").
+    """
+    prefix = f"{group}_"
+    return col[len(prefix) :] if col.startswith(prefix) else col
+
+
 def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) -> None:
     """Create the training tab UI and wire up event handlers.
 
@@ -77,8 +130,6 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
     """
     with gr.Row():
         with gr.Column(scale=1):
-            # Model types match shared.constants.MODEL_HYPERPARAMETERS keys.
-            # Update here if new model types are added to shared/.
             model_type = gr.Dropdown(
                 choices=["logistic_regression", "xgboost", "random_forest"],
                 value="logistic_regression",
@@ -91,6 +142,41 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 value=0.2,
                 label="Test Size",
             )
+
+            gr.Markdown("### Feature Selection")
+
+            # Numeric features — each maps to a single encoded column
+            numeric_choices = [
+                (FEATURE_GROUP_LABELS[f], f) for f in NUMERIC_FEATURES
+            ]
+            numeric_group = gr.CheckboxGroup(
+                choices=numeric_choices,
+                value=list(NUMERIC_FEATURES),
+                label="Numeric Features",
+            )
+
+            # Categorical features — each has multiple one-hot columns
+            cat_col_groups: list[gr.CheckboxGroup] = []
+            cat_select_alls: list[gr.Checkbox] = []
+            cat_all_cols: list[list[str]] = []
+
+            for cat_name in CATEGORICAL_FEATURES:
+                label = FEATURE_GROUP_LABELS[cat_name]
+                columns = FEATURE_GROUPS[cat_name]
+                col_choices = [
+                    (_column_display_name(c, cat_name), c) for c in columns
+                ]
+                with gr.Accordion(label, open=False):
+                    select_all = gr.Checkbox(value=True, label="Select All")
+                    col_group = gr.CheckboxGroup(
+                        choices=col_choices,
+                        value=list(columns),
+                        label=f"{label} Columns",
+                    )
+                cat_select_alls.append(select_all)
+                cat_col_groups.append(col_group)
+                cat_all_cols.append(list(columns))
+
             train_btn = gr.Button("Train Model", variant="primary")
 
         with gr.Column(scale=2):
@@ -99,40 +185,121 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 label="Model Metrics",
                 interactive=False,
             )
-            threshold_display = gr.Textbox(label="Optimal Threshold", interactive=False)
-            training_time_display = gr.Textbox(label="Training Time", interactive=False)
+            threshold_display = gr.Textbox(
+                label="Optimal Threshold", interactive=False
+            )
+            training_time_display = gr.Textbox(
+                label="Training Time", interactive=False
+            )
             model_id_display = gr.Textbox(label="Model ID", interactive=False)
             roc_plot = gr.Plot(label="ROC Curve")
-            error_display = gr.Textbox(label="Status", interactive=False, visible=False)
+            importance_plot = gr.Plot(label="Feature Importance")
+            error_display = gr.Textbox(
+                label="Status", interactive=False, visible=False
+            )
+
+    # Wire up Select All ↔ column toggle events for each categorical group.
+    # Uses .input() for Select All to avoid event loops: .input() fires only
+    # on direct user interaction, not programmatic updates.
+    for i in range(len(CATEGORICAL_FEATURES)):
+        select_all_cb = cat_select_alls[i]
+        col_group_cb = cat_col_groups[i]
+        all_cols = cat_all_cols[i]
+
+        def _toggle_all(checked: bool, cols: list[str] = all_cols) -> list[str]:
+            """Check or uncheck all columns when Select All is toggled."""
+            return cols if checked else []
+
+        def _sync_select_all(
+            selected: list[str], cols: list[str] = all_cols
+        ) -> bool:
+            """Update Select All checkbox to reflect column selection state."""
+            return len(selected) == len(cols)
+
+        select_all_cb.input(
+            fn=_toggle_all, inputs=[select_all_cb], outputs=[col_group_cb]
+        )
+        col_group_cb.change(
+            fn=_sync_select_all, inputs=[col_group_cb], outputs=[select_all_cb]
+        )
+
+    # Build train inputs: model config + numeric features + categorical columns + state
+    train_inputs: list[Any] = [
+        model_type,
+        test_size,
+        numeric_group,
+        *cat_col_groups,
+        training_results_state,
+    ]
+
+    train_outputs: list[Any] = [
+        metrics_table,
+        threshold_display,
+        training_time_display,
+        model_id_display,
+        roc_plot,
+        importance_plot,
+        error_display,
+        training_results_state,
+    ]
 
     def _train(
         selected_model_type: str,
         selected_test_size: float,
-        training_results: dict[str, dict[str, Any]],
-    ) -> tuple[
-        Any,  # metrics_table
-        str,  # threshold_display
-        str,  # training_time_display
-        str,  # model_id_display
-        go.Figure | None,  # roc_plot
-        Any,  # error_display update
-        dict[str, dict[str, Any]],  # updated training_results_state
-    ]:
+        numeric_selected: list[str],
+        *args: Any,
+    ) -> tuple[Any, ...]:
         """Handle train button click.
 
         Args:
             selected_model_type: Model type from dropdown.
             selected_test_size: Test/train split ratio.
-            training_results: Session-scoped training results cache.
+            numeric_selected: Selected numeric feature group names.
+            *args: Categorical column selections (one list per group) followed
+                by the training_results state dict as the last element.
 
         Returns:
             Tuple of updated component values and updated state.
         """
+        # Last arg is training_results state; rest are categorical column selections
+        training_results: dict[str, dict[str, Any]] = args[-1]
+        cat_selections = args[:-1]
+
+        # Collect all selected encoded column names
+        selected_features: list[str] = list(numeric_selected)
+        for sel in cat_selections:
+            selected_features.extend(sel)
+
+        if not selected_features:
+            return (
+                [],
+                "",
+                "",
+                "",
+                None,
+                None,
+                gr.update(
+                    visible=True,
+                    value="Please select at least one feature to train on.",
+                ),
+                training_results,
+            )
+
+        # Send None when all features are selected (backward compatible)
+        features_param = (
+            selected_features
+            if len(selected_features) < len(ALL_FEATURES)
+            else None
+        )
+
         try:
-            config = {
+            config: dict[str, Any] = {
                 "model_type": selected_model_type,
                 "test_size": selected_test_size,
             }
+            if features_param is not None:
+                config["selected_features"] = features_param
+
             result = api.train(config)
 
             # Store result in session state for comparison tab
@@ -146,7 +313,15 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
 
             roc_fig = None
             if "roc_curve" in metrics:
-                roc_fig = _build_roc_plot(metrics["roc_curve"], selected_model_type)
+                roc_fig = _build_roc_plot(
+                    metrics["roc_curve"], selected_model_type
+                )
+
+            importance_fig = None
+            if result.get("feature_importance"):
+                importance_fig = _build_importance_plot(
+                    result["feature_importance"]
+                )
 
             return (
                 table_data,
@@ -154,6 +329,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 f"{train_time:.3f}s",
                 model_id,
                 roc_fig,
+                importance_fig,
                 gr.update(visible=False, value=""),
                 training_results,
             )
@@ -172,6 +348,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 "",
                 "",
                 None,
+                None,
                 gr.update(visible=True, value=msg),
                 training_results,
             )
@@ -182,6 +359,7 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 "",
                 "",
                 "",
+                None,
                 None,
                 gr.update(
                     visible=True,
@@ -200,14 +378,6 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
         outputs=[error_display],
     ).then(
         fn=_train,
-        inputs=[model_type, test_size, training_results_state],
-        outputs=[
-            metrics_table,
-            threshold_display,
-            training_time_display,
-            model_id_display,
-            roc_plot,
-            error_display,
-            training_results_state,
-        ],
+        inputs=train_inputs,
+        outputs=train_outputs,
     )

--- a/docs/1-ADRs/ADR-010-feature-selection.md
+++ b/docs/1-ADRs/ADR-010-feature-selection.md
@@ -1,0 +1,149 @@
+# ADR-010: Training Feature Selection
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Date | 2026-02-07 |
+
+## Context
+
+Previously, all 26 encoded features (7 numeric + 19 one-hot from 4 categorical groups) were always used for training. Users had no way to:
+
+1. Exclude potentially leaky features (e.g. `loan_grade`, which is derived from other applicant data)
+2. Assess which features are informative via importance scores
+3. Experiment with feature subsets to understand model behavior
+
+### Feature Inventory
+
+| Group | Label | Type | Encoded Columns |
+|-------|-------|------|-----------------|
+| `person_age` | Age | numeric | 1 |
+| `person_income` | Income | numeric | 1 |
+| `person_emp_length` | Employment Length | numeric | 1 |
+| `loan_amnt` | Loan Amount | numeric | 1 |
+| `loan_int_rate` | Interest Rate | numeric | 1 |
+| `loan_percent_income` | Loan % of Income | numeric | 1 |
+| `cb_person_cred_hist_length` | Credit History Length | numeric | 1 |
+| `person_home_ownership` | Home Ownership | categorical | 4 (MORTGAGE, OTHER, OWN, RENT) |
+| `loan_intent` | Loan Intent | categorical | 6 (DEBTCONSOLIDATION, EDUCATION, ...) |
+| `loan_grade` | Loan Grade | categorical | 7 (A through G) |
+| `cb_person_default_on_file` | Previous Default | categorical | 2 (Y, N) |
+| | | **Total** | **26** |
+
+## Decision
+
+### API Layer
+
+Add `selected_features: list[str] | None` to `TrainingConfig`:
+
+```python
+selected_features: list[str] | None = Field(
+    default=None,
+    description="Encoded column names to train on. None = all features.",
+)
+```
+
+- `None` (default) = train on all 26 features (backward compatible)
+- Explicit list = train on only those encoded column names
+
+The API operates at the **encoded column** level, providing maximum granularity.
+
+### Feature Groups Abstraction
+
+`shared/constants.py` provides `FEATURE_GROUPS` mapping group names to their encoded columns:
+
+```mermaid
+graph TD
+    subgraph "Feature Group: person_home_ownership"
+        G[person_home_ownership] --> C1[person_home_ownership_MORTGAGE]
+        G --> C2[person_home_ownership_OTHER]
+        G --> C3[person_home_ownership_OWN]
+        G --> C4[person_home_ownership_RENT]
+    end
+```
+
+This allows UIs to present category-level toggles while sending column-level selections to the API.
+
+### Gradio UI
+
+```
+Feature Selection
+├── [✓] Numeric Features (CheckboxGroup)
+│   ├── Age, Income, Employment Length, ...
+├── ▼ Home Ownership (Accordion)
+│   ├── [✓] Select All
+│   └── [✓] MORTGAGE  [✓] OTHER  [✓] OWN  [✓] RENT
+├── ▼ Loan Intent (Accordion)
+│   ├── [✓] Select All
+│   └── [✓] DEBTCONSOLIDATION  [✓] EDUCATION  ...
+├── ▼ Loan Grade (Accordion)
+│   ├── [✓] Select All
+│   └── [✓] A  [✓] B  [✓] C  [✓] D  [✓] E  [✓] F  [✓] G
+└── ▼ Previous Default (Accordion)
+    ├── [✓] Select All
+    └── [✓] N  [✓] Y
+```
+
+- **Category-level**: checking/unchecking Select All toggles all one-hot columns
+- **Column-level**: individual one-hot columns can be independently toggled
+- Select All checkbox syncs bidirectionally: unchecking any column unchecks Select All; checking all columns re-checks it
+- Uses `.input()` for Select All to prevent event loops (fires only on user interaction, not programmatic updates)
+
+### Feature Importance
+
+Feature importance is now extracted for **all** model types:
+
+| Model | Source | Metric |
+|-------|--------|--------|
+| XGBoost | `feature_importances_` | Gain-based importance |
+| Random Forest | `feature_importances_` | Mean decrease in impurity |
+| Logistic Regression | `abs(coef_[0])` | Absolute coefficient magnitude |
+
+Displayed as a horizontal bar chart sorted by importance.
+
+### Model ID Format
+
+Updated to include feature count for traceability:
+
+```
+{model_type}_test{pct}_{n_features}f_{uuid6}
+```
+
+Examples:
+- `logistic_regression_test20_26f_a1b2c3` (all features)
+- `xgboost_test20_19f_d4e5f6` (subset, e.g. without loan grade)
+
+### Prediction-Time Feature Subsetting
+
+Models trained on a feature subset store their `feature_columns` in the model store. At prediction time, the inference service:
+
+1. Creates the full 26-element feature vector from the loan application
+2. Selects only the columns the model was trained on (via stored indices)
+3. Passes the subsetted vector to `model.predict_proba()`
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `shared/constants.py` | `FEATURE_GROUPS`, `ALL_FEATURE_GROUPS`, `FEATURE_GROUP_LABELS` |
+| `shared/schemas/training.py` | `selected_features` field on `TrainingConfig` |
+| `apps/api/services/training.py` | Feature subsetting in `load_dataset_from_csv`, LR importance, model ID format |
+| `apps/api/services/model_store.py` | `feature_columns` storage and retrieval |
+| `apps/api/services/inference.py` | Feature-filtered predictions |
+| `apps/gradio/components/training_tab.py` | Feature selection UI + importance chart |
+
+## Alternatives Considered
+
+- **Feature selection via separate endpoint** — More RESTful but adds complexity; embedding in `TrainingConfig` is simpler and keeps selection tied to the training run
+- **Group-level API (`selected_groups`)** — Simpler API but loses the ability to exclude individual one-hot columns (e.g. include `loan_grade_A` through `loan_grade_E` but exclude `F` and `G`)
+- **Automatic feature selection (RFE, LASSO)** — Valuable but orthogonal; users should first be able to manually select features before adding automated methods
+- **Store feature columns in ModelMetadata schema** — Would require schema migration; storing in model store dict is simpler and doesn't affect API contract
+
+## Consequences
+
+- All existing API clients and tests remain backward compatible (`selected_features: None`)
+- Users can now exclude leaky features like `loan_grade` to build more realistic models
+- Feature importance chart helps users make informed feature selection decisions
+- Logistic regression now returns importance (previously only tree models did)
+- Model ID is now longer but more informative
+- Prediction service has a small overhead for column index lookup (negligible)

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -46,6 +46,62 @@ CATEGORICAL_FEATURES: list[str] = [
 # All feature columns (numeric + encoded categorical)
 ALL_FEATURES: list[str] = NUMERIC_FEATURES + CATEGORICAL_FEATURES_ENCODED
 
+# Feature groups: maps a logical feature name to its encoded column(s).
+# Numeric features map 1:1; categorical features expand to their one-hot columns.
+FEATURE_GROUPS: dict[str, list[str]] = {
+    "person_age": ["person_age"],
+    "person_income": ["person_income"],
+    "person_emp_length": ["person_emp_length"],
+    "loan_amnt": ["loan_amnt"],
+    "loan_int_rate": ["loan_int_rate"],
+    "loan_percent_income": ["loan_percent_income"],
+    "cb_person_cred_hist_length": ["cb_person_cred_hist_length"],
+    "person_home_ownership": [
+        "person_home_ownership_MORTGAGE",
+        "person_home_ownership_OTHER",
+        "person_home_ownership_OWN",
+        "person_home_ownership_RENT",
+    ],
+    "loan_intent": [
+        "loan_intent_DEBTCONSOLIDATION",
+        "loan_intent_EDUCATION",
+        "loan_intent_HOMEIMPROVEMENT",
+        "loan_intent_MEDICAL",
+        "loan_intent_PERSONAL",
+        "loan_intent_VENTURE",
+    ],
+    "loan_grade": [
+        "loan_grade_A",
+        "loan_grade_B",
+        "loan_grade_C",
+        "loan_grade_D",
+        "loan_grade_E",
+        "loan_grade_F",
+        "loan_grade_G",
+    ],
+    "cb_person_default_on_file": [
+        "cb_person_default_on_file_N",
+        "cb_person_default_on_file_Y",
+    ],
+}
+
+ALL_FEATURE_GROUPS: list[str] = list(FEATURE_GROUPS.keys())
+
+# Human-readable labels for feature groups (used in Gradio UI)
+FEATURE_GROUP_LABELS: dict[str, str] = {
+    "person_age": "Age",
+    "person_income": "Income",
+    "person_emp_length": "Employment Length",
+    "loan_amnt": "Loan Amount",
+    "loan_int_rate": "Interest Rate",
+    "loan_percent_income": "Loan % of Income",
+    "cb_person_cred_hist_length": "Credit History Length",
+    "person_home_ownership": "Home Ownership",
+    "loan_intent": "Loan Intent",
+    "loan_grade": "Loan Grade",
+    "cb_person_default_on_file": "Previous Default",
+}
+
 # Target column
 TARGET_COLUMN: str = "loan_status"
 

--- a/shared/schemas/training.py
+++ b/shared/schemas/training.py
@@ -16,6 +16,7 @@ class TrainingConfig(BaseModel):
         random_state: Random seed for reproducibility.
         undersample: Whether to undersample the majority class for imbalanced data.
         cv_folds: Number of cross-validation folds (2-10).
+        selected_features: Encoded column names to train on. None = all features.
     """
 
     model_type: Literal["logistic_regression", "xgboost", "random_forest"] = Field(
@@ -27,6 +28,10 @@ class TrainingConfig(BaseModel):
     random_state: int = Field(default=42, description="Random seed for reproducibility")
     undersample: bool = Field(default=False, description="Undersample majority class")
     cv_folds: int = Field(default=5, ge=2, le=10, description="CV folds")
+    selected_features: list[str] | None = Field(
+        default=None,
+        description="Encoded column names to train on. None = all features.",
+    )
 
 
 class TrainingResult(BaseModel):


### PR DESCRIPTION
## Summary

- Users can now select which features to train on via category-level checkboxes with individual one-hot column control
- Feature importance chart displayed after training for all model types (including logistic regression)
- Model IDs include feature count for traceability (e.g. `logistic_regression_test20_26f_a1b2c3`)
- Prediction service correctly subsets features to match the model's training columns

## Files Changed (6)

| File | Change |
|------|--------|
| `shared/constants.py` | `FEATURE_GROUPS`, `ALL_FEATURE_GROUPS`, `FEATURE_GROUP_LABELS` |
| `shared/schemas/training.py` | `selected_features` field on `TrainingConfig` |
| `apps/api/services/training.py` | Feature subsetting, LR importance, model ID format |
| `apps/api/services/model_store.py` | Store/retrieve `feature_columns` per model |
| `apps/api/services/inference.py` | Feature-filtered predictions |
| `apps/gradio/components/training_tab.py` | Feature selection UI + importance chart |

## Backward Compatibility

- `selected_features: None` (default) trains on all 26 features — identical to current behavior
- All 105 existing tests pass without modification

## Test plan

- [ ] Train with all features checked — same results as before
- [ ] Uncheck "Loan Grade" — model trains on 19 features
- [ ] Feature importance chart appears for logistic regression, XGBoost, and random forest
- [ ] Predict with a feature-subset model — correct results
- [ ] `pytest tests/ -x -q` passes (105 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)