### PR TITLE
fix(ci): copy shared/constants.py to HF Spaces deployment

### DIFF
--- a/.github/workflows/sync_to_hf_hub.yml
+++ b/.github/workflows/sync_to_hf_hub.yml
@@ -3,7 +3,9 @@ name: Deploy Gradio to HF Spaces
 on:
   push:
     branches: [main]
-    paths: [apps/gradio/**]
+    paths:
+      - apps/gradio/**
+      - shared/constants.py
   workflow_dispatch:
 
 jobs:
@@ -48,8 +50,11 @@ jobs:
       # Copy apps/gradio/* and rewrite monorepo imports for flat layout
       - name: Prepare deployment
         run: |
-          mkdir -p /tmp/hf-deploy
+          mkdir -p /tmp/hf-deploy/shared
           cp -r apps/gradio/* /tmp/hf-deploy/
+          # Copy shared/constants.py with a minimal __init__.py (avoids heavy deps)
+          echo '"""Shared constants for HF Spaces."""' > /tmp/hf-deploy/shared/__init__.py
+          cp shared/constants.py /tmp/hf-deploy/shared/constants.py
           cd /tmp/hf-deploy
           sed -i 's/from apps\.gradio\./from /g' app.py
           sed -i 's/from apps\.gradio\./from /g' components/*.py


### PR DESCRIPTION
## Summary

- Training tab now imports from `shared.constants` (added in #31), but HF Spaces only deploys `apps/gradio/` — missing `shared/` module causes `ModuleNotFoundError`
- Copy `shared/constants.py` with a minimal `__init__.py` to avoid pulling in heavy deps (pydantic, numpy, sklearn)
- Also trigger HF deploy workflow on `shared/constants.py` changes

## Test plan

- [ ] HF Spaces deploy succeeds without `ModuleNotFoundError`
- [ ] Training tab loads with feature selection checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)