### PR TITLE
fix(gradio): fix compare tab not showing trained models

### DIFF
--- a/apps/gradio/api_client.py
+++ b/apps/gradio/api_client.py
@@ -110,6 +110,24 @@ class CreditRiskAPI:
         response.raise_for_status()
         return response.json()
 
+    def get_model_results(self, model_id: str) -> dict[str, Any]:
+        """Get full training results for a specific model.
+
+        Args:
+            model_id: Model identifier.
+
+        Returns:
+            TrainingResult dictionary with metrics, ROC curve, etc.
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error status.
+        """
+        response = self.client.get(
+            f"{self.base_url}/models/{model_id}/results", headers=self._headers()
+        )
+        response.raise_for_status()
+        return response.json()
+
     def verify_key(self) -> bool:
         """Verify the current API key against the auth endpoint.
 


### PR DESCRIPTION
## Summary
- **Fix silent failures on refresh**: `_get_model_choices()` now returns status messages instead of silently swallowing errors — users see "No trained models found" or "Failed to connect to API" instead of an empty dropdown with no explanation
- **Fix dual state mismatch**: Compare tab now fetches missing training results from the API via `GET /models/{id}/results` instead of only checking Gradio session state — models no longer require being trained in the current browser session to compare
- **Add explicit Compare button**: Replaces the unreliable `.change()` event on the multiselect dropdown with a dedicated button trigger

## Test plan
- [ ] Start API and Gradio app
- [ ] Train 2+ models in the Train tab
- [ ] Switch to Compare tab, click Refresh Models — verify status shows "Found N model(s)"
- [ ] Select models from dropdown, click Compare — verify ROC curves, bar chart, and metrics table appear
- [ ] Refresh the browser page, go to Compare tab, click Refresh — verify models still appear in dropdown
- [ ] Select previously trained models and click Compare — verify results load from API
- [ ] Stop the API server, click Refresh — verify "Failed to connect to API" message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)