### PR TITLE
docs: clean up ADR/RFC author, links, and references

### DIFF
--- a/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
+++ b/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented |
-| Author(s) | Claude |
+| Author(s) | Paul / Claude |
 | Updated | 2026-02-01 |
 | GitHub Issue | — |
 | Obsoletes | — |

--- a/docs/0-RFCs/RFC-002-api-layer.md
+++ b/docs/0-RFCs/RFC-002-api-layer.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented |
-| Author(s) | [Your Name] |
+| Author(s) | Paul / Claude |
 | Updated | 2026-02-01 |
 | Depends On | RFC-001 |
 

--- a/docs/0-RFCs/RFC-006-auth-polish.md
+++ b/docs/0-RFCs/RFC-006-auth-polish.md
@@ -5,7 +5,7 @@
 | Status | Implemented |
 | Author(s) | pkiage |
 | Updated | 2026-02-02 |
-| Depends On | RFC-001, RFC-002, RFC-004, RFC-005 |
+| Depends On | RFC-001, RFC-002 |
 
 ## Objective
 

--- a/docs/0-RFCs/RFC-006-auth-polish.md
+++ b/docs/0-RFCs/RFC-006-auth-polish.md
@@ -5,7 +5,7 @@
 | Status | Implemented |
 | Author(s) | pkiage |
 | Updated | 2026-02-02 |
-| Depends On | RFC-001, RFC-002 |
+| Depends On | [RFC-001](RFC-001-CreditRiskPlatformArchitecture.md), [RFC-002](RFC-002-api-layer.md) |
 
 ## Objective
 

--- a/docs/1-ADRs/ADR-001-shared-layer-foundation.md
+++ b/docs/1-ADRs/ADR-001-shared-layer-foundation.md
@@ -5,7 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2025-01-31 |
-| RFC | RFC-001 |
+| RFC | [RFC-001](../0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md) |
 | PR | [link to merged PR] |
 
 ## Context

--- a/docs/1-ADRs/ADR-001-shared-layer-foundation.md
+++ b/docs/1-ADRs/ADR-001-shared-layer-foundation.md
@@ -6,7 +6,7 @@
 | Author | Paul / Claude |
 | Date | 2025-01-31 |
 | RFC | [RFC-001](../0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md) |
-| PR | [link to merged PR] |
+| PR | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-001-shared-layer-foundation.md
+++ b/docs/1-ADRs/ADR-001-shared-layer-foundation.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2025-01-31 |
 | RFC | RFC-001 |
 | PR | [link to merged PR] |

--- a/docs/1-ADRs/ADR-002-pydantic-as-contract.md
+++ b/docs/1-ADRs/ADR-002-pydantic-as-contract.md
@@ -6,6 +6,7 @@
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | [RFC-001](../0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md) |
+| PR | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-002-pydantic-as-contract.md
+++ b/docs/1-ADRs/ADR-002-pydantic-as-contract.md
@@ -5,7 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
-| RFC | RFC-001 |
+| RFC | [RFC-001](../0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-002-pydantic-as-contract.md
+++ b/docs/1-ADRs/ADR-002-pydantic-as-contract.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | RFC-001 |
 

--- a/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
+++ b/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
@@ -5,7 +5,6 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
-| RFC | RFC-003 |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
+++ b/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
@@ -5,6 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
+| PR | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
+++ b/docs/1-ADRs/ADR-003-marimo-over-jupyter.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | RFC-003 |
 

--- a/docs/1-ADRs/ADR-004-api-key-authentication.md
+++ b/docs/1-ADRs/ADR-004-api-key-authentication.md
@@ -5,7 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
-| RFC | RFC-006 |
+| RFC | [RFC-006](../0-RFCs/RFC-006-auth-polish.md) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-004-api-key-authentication.md
+++ b/docs/1-ADRs/ADR-004-api-key-authentication.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | RFC-006 |
 

--- a/docs/1-ADRs/ADR-004-api-key-authentication.md
+++ b/docs/1-ADRs/ADR-004-api-key-authentication.md
@@ -6,6 +6,7 @@
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | [RFC-006](../0-RFCs/RFC-006-auth-polish.md) |
+| PR | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-005-model-persistence-strategy.md
+++ b/docs/1-ADRs/ADR-005-model-persistence-strategy.md
@@ -5,7 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
-| RFC | RFC-006 |
+| RFC | [RFC-006](../0-RFCs/RFC-006-auth-polish.md) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-005-model-persistence-strategy.md
+++ b/docs/1-ADRs/ADR-005-model-persistence-strategy.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | RFC-006 |
 

--- a/docs/1-ADRs/ADR-005-model-persistence-strategy.md
+++ b/docs/1-ADRs/ADR-005-model-persistence-strategy.md
@@ -6,6 +6,7 @@
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | [RFC-006](../0-RFCs/RFC-006-auth-polish.md) |
+| PR | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-006-ui-progression.md
+++ b/docs/1-ADRs/ADR-006-ui-progression.md
@@ -5,6 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-01 |
+| PR | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-006-ui-progression.md
+++ b/docs/1-ADRs/ADR-006-ui-progression.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-01 |
 | RFC | RFC-004 |
 

--- a/docs/1-ADRs/ADR-006-ui-progression.md
+++ b/docs/1-ADRs/ADR-006-ui-progression.md
@@ -5,7 +5,6 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-01 |
-| RFC | RFC-004 |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-007-chart-library.md
+++ b/docs/1-ADRs/ADR-007-chart-library.md
@@ -5,6 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
+| PR | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-007-chart-library.md
+++ b/docs/1-ADRs/ADR-007-chart-library.md
@@ -5,7 +5,6 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
-| RFC | RFC-005 |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-007-chart-library.md
+++ b/docs/1-ADRs/ADR-007-chart-library.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 | RFC | RFC-005 |
 

--- a/docs/1-ADRs/ADR-008-monorepo-structure.md
+++ b/docs/1-ADRs/ADR-008-monorepo-structure.md
@@ -5,6 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-02 |
+| PR | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-008-monorepo-structure.md
+++ b/docs/1-ADRs/ADR-008-monorepo-structure.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-02 |
 
 ## Context

--- a/docs/1-ADRs/ADR-009-cloud-run-deployment.md
+++ b/docs/1-ADRs/ADR-009-cloud-run-deployment.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-07 |
 | PR | [#30](https://github.com/pkiage/tool-credit-risk-modelling/pull/30) |
 

--- a/docs/1-ADRs/ADR-010-feature-selection.md
+++ b/docs/1-ADRs/ADR-010-feature-selection.md
@@ -5,6 +5,7 @@
 | Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-07 |
+| PR | [#31](https://github.com/pkiage/tool-credit-risk-modelling/pull/31) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-010-feature-selection.md
+++ b/docs/1-ADRs/ADR-010-feature-selection.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Accepted |
+| Author | Paul / Claude |
 | Date | 2026-02-07 |
 
 ## Context


### PR DESCRIPTION
## Summary

- Add `Author | Paul / Claude` to all 10 ADRs (previously missing)
- Fix RFC-001 and RFC-002 author fields (`Claude` and `[Your Name]` → `Paul / Claude`)
- Remove references to RFC-003, RFC-004, RFC-005 (converted to ADRs in PR #21, files no longer exist)
- Hyperlink valid RFC references in ADRs and RFC-006 Depends On field
- Add PR links to all ADRs based on git history (#19, #21, #30, #31)

## Test plan

- [x] No remaining `[Your Name]` or `[link to merged PR]` placeholders
- [x] No references to RFC-003, RFC-004, or RFC-005
- [x] All RFC hyperlinks point to existing files
- [x] All PR links are valid GitHub URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)