### PR TITLE
feat(marimo): deploy notebooks to HF Spaces (Docker)

### DIFF
--- a/.github/workflows/deploy-notebooks-hf.yml
+++ b/.github/workflows/deploy-notebooks-hf.yml
@@ -1,0 +1,77 @@
+name: Deploy Marimo Notebooks to HF Spaces
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - notebooks/**
+      - shared/**
+      - data/processed/**
+      - apps/marimo/**
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Create Docker Space (if it doesn't exist)
+      - name: Setup HF Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          pip install huggingface_hub
+          python << 'SETUP'
+          import os
+          from huggingface_hub import HfApi
+
+          token = os.environ["HF_TOKEN"]
+          api = HfApi(token=token)
+          api.create_repo(
+              "pkiage/credit-risk-notebooks",
+              repo_type="space",
+              space_sdk="docker",
+              exist_ok=True,
+          )
+          print("HF Space ready")
+          SETUP
+
+      # Assemble flat layout: Dockerfile, server.py, requirements.txt,
+      # README.md at root, with notebooks/, shared/, and data/ alongside.
+      - name: Prepare deployment
+        run: |
+          mkdir -p /tmp/hf-deploy/notebooks
+          mkdir -p /tmp/hf-deploy/data/processed
+
+          # App files
+          cp apps/marimo/Dockerfile /tmp/hf-deploy/
+          cp apps/marimo/server.py /tmp/hf-deploy/
+          cp apps/marimo/requirements.txt /tmp/hf-deploy/
+          cp apps/marimo/README.md /tmp/hf-deploy/
+
+          # Full shared/ tree (notebooks import logic + schemas)
+          cp -r shared /tmp/hf-deploy/shared
+
+          # Notebooks
+          cp notebooks/*.py /tmp/hf-deploy/notebooks/
+
+          # Training dataset
+          cp data/processed/cr_loan_w2.csv /tmp/hf-deploy/data/processed/
+
+      # Push to HF Spaces
+      - name: Deploy to HF Spaces
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          cd /tmp/hf-deploy
+          git init -b main
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+          git commit -m "Deploy from ${{ github.sha }}"
+          git push --force https://pkiage:$HF_TOKEN@huggingface.co/spaces/pkiage/credit-risk-notebooks main

--- a/apps/marimo/Dockerfile
+++ b/apps/marimo/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+RUN useradd -m -u 1000 user
+
+ENV PATH="/home/user/.local/bin:$PATH"
+ENV UV_SYSTEM_PYTHON=1
+ENV PYTHONPATH=/app
+
+WORKDIR /app
+
+COPY --chown=user ./requirements.txt requirements.txt
+RUN uv pip install -r requirements.txt
+
+COPY --chown=user . /app
+
+RUN mkdir -p /app/__marimo__ && \
+    chown -R user:user /app && \
+    chmod -R 755 /app
+
+USER user
+
+CMD ["python", "server.py"]

--- a/apps/marimo/README.md
+++ b/apps/marimo/README.md
@@ -1,0 +1,20 @@
+---
+title: Credit Risk Notebooks
+emoji: "\U0001F4D3"
+sdk: docker
+app_port: 7860
+pinned: false
+---
+
+# Credit Risk Notebooks
+
+Interactive Marimo notebooks for exploring credit risk model training, evaluation, and threshold optimization.
+
+## Notebooks
+
+| Route | Notebook | Description |
+| ----- | -------- | ----------- |
+| `/01_eda` | Exploratory Data Analysis | Dataset overview, distributions, correlations |
+| `/02_model_comparison` | Model Comparison | Train and compare Logistic Regression, XGBoost, Random Forest |
+| `/03_threshold_optimization` | Threshold Optimization | Interactive threshold tuning with Youden's J |
+| `/04_calibration` | Probability Calibration | Calibration curves and Brier score analysis |

--- a/apps/marimo/requirements.txt
+++ b/apps/marimo/requirements.txt
@@ -1,0 +1,8 @@
+marimo>=0.13
+uvicorn>=0.34
+numpy>=1.26
+pandas>=2.2
+scikit-learn>=1.5
+xgboost>=2.1
+plotly>=5.22
+pydantic>=2.7

--- a/apps/marimo/server.py
+++ b/apps/marimo/server.py
@@ -18,4 +18,4 @@ for nb in sorted(notebooks_dir.glob("*.py")):
 app = server.build()
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=7860)
+    uvicorn.run(app, host="0.0.0.0", port=7860)  # nosec B104 — Docker container requires binding to all interfaces

--- a/apps/marimo/server.py
+++ b/apps/marimo/server.py
@@ -1,0 +1,21 @@
+"""Multi-notebook Marimo ASGI server for HF Spaces deployment."""
+
+from pathlib import Path
+
+import marimo
+import uvicorn
+
+# Resolve notebooks directory: works both in the monorepo (apps/marimo/server.py)
+# and in the flat HF Spaces layout (server.py alongside notebooks/).
+_here = Path(__file__).parent
+_candidates = [_here / "notebooks", _here.parent.parent / "notebooks"]
+notebooks_dir = next((d for d in _candidates if d.is_dir()), _candidates[0])
+
+server = marimo.create_asgi_app(quiet=True, include_code=True)
+for nb in sorted(notebooks_dir.glob("*.py")):
+    server = server.with_app(path=f"/{nb.stem}", root=str(nb))
+
+app = server.build()
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=7860)


### PR DESCRIPTION
## Summary

- Add Docker-based HF Spaces deployment for all 4 Marimo notebooks served from a single URL
- Create multi-notebook ASGI server using `marimo.create_asgi_app()` with routes: `/01_eda`, `/02_model_comparison`, `/03_threshold_optimization`, `/04_calibration`
- Add GitHub Actions workflow that bundles `shared/`, `notebooks/`, and training data into a flat layout for HF Spaces
- Include code visibility enabled (`include_code=True`) for educational transparency

## New Files

| File | Purpose |
| ---- | ------- |
| `apps/marimo/server.py` | Multi-notebook ASGI server |
| `apps/marimo/Dockerfile` | Docker image (python:3.12-slim + uv) |
| `apps/marimo/requirements.txt` | Runtime dependencies |
| `apps/marimo/README.md` | HF Spaces metadata (sdk: docker, port: 7860) |
| `.github/workflows/deploy-notebooks-hf.yml` | CI/CD: auto-deploy on push to main |

## How It Works

1. GitHub Actions assembles a flat deploy directory with `Dockerfile`, `server.py`, full `shared/` tree, `notebooks/*.py`, and `data/processed/cr_loan_w2.csv`
2. Pushes to HF Space `pkiage/credit-risk-notebooks` which builds the Docker image
3. `server.py` discovers all notebooks in `notebooks/` and mounts them as interactive apps
4. Full Python runtime — sklearn, xgboost, plotly all work natively

## Test plan

- [ ] Verify GitHub Actions workflow syntax is valid
- [ ] Confirm Docker image builds successfully on HF Spaces
- [ ] Test each notebook route loads and renders
- [ ] Verify interactive widgets (file upload, sliders, dropdowns) work
- [ ] Confirm model training runs in `02_model_comparison`
- [ ] Validate `shared/` imports resolve correctly in all notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)