### PR TITLE
feat(web): add Cloud Run deployment for Next.js app

### DIFF
--- a/.github/workflows/deploy-web-cloudrun.yml
+++ b/.github/workflows/deploy-web-cloudrun.yml
@@ -1,0 +1,58 @@
+name: Deploy Web to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/web/**
+  workflow_dispatch:
+
+env:
+  SERVICE: credit-risk-web
+  REGION: ${{ secrets.GCP_REGION }}
+  IMAGE: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/credit-risk/web
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build image
+        run: |
+          docker build \
+            -f apps/web/Dockerfile \
+            --build-arg NEXT_PUBLIC_API_URL=${{ secrets.CREDIT_RISK_API_URL }} \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest \
+            apps/web/
+
+      - name: Push image
+        run: |
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.IMAGE }}:${{ github.sha }}
+          flags: >-
+            --allow-unauthenticated
+            --memory=512Mi
+            --cpu=1
+            --timeout=60
+            --port=3000
+            --min-instances=0
+            --max-instances=2

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,46 @@
+# Credit Risk Web UI — multi-stage build for Google Cloud Run
+# Build context: apps/web/ (not repo root, unlike the API Dockerfile).
+
+FROM node:22-alpine AS base
+
+# --- Stage 1: Install dependencies ---
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# --- Stage 2: Build the application ---
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_ vars are inlined at build time into the client bundle
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
+RUN npm run build
+
+# --- Stage 3: Production image ---
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -24,6 +24,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+	output: "standalone",
 	async headers() {
 		return [
 			{

--- a/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
+++ b/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
@@ -1,0 +1,74 @@
+# ADR-011: Next.js Deployment on Cloud Run
+
+| Field | Value |
+|-------|-------|
+| Status | Proposed |
+| Author | Paul / Claude |
+| Date | 2026-02-07 |
+
+## Context
+
+The Next.js frontend (`apps/web/`) is the only app in the monorepo without automated deployment. The FastAPI backend deploys to Cloud Run (ADR-009), and the Gradio demo deploys to HF Spaces. The web app needs a hosting platform that:
+
+- Supports server-side middleware (cookie-based auth in `middleware.ts`)
+- Fits within free tier for a demo/portfolio project
+- Integrates with the existing GitHub Actions CI/CD pipeline
+- Requires minimal new infrastructure
+
+## Decision
+
+Deploy the Next.js app to **Google Cloud Run** using a multi-stage Docker build and a GitHub Actions workflow that mirrors the existing API deployment.
+
+### Infrastructure
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| Memory | 512 Mi | Lighter than API (no sklearn/pandas) |
+| CPU | 1 | Sufficient for SSR + middleware |
+| Timeout | 60 s | No long-running operations |
+| Min instances | 0 | Scale to zero (free tier) |
+| Max instances | 2 | Cap runaway scaling |
+| Port | 3000 | Next.js default |
+| Auth | `--allow-unauthenticated` | App-level auth via cookies |
+
+### Build Strategy
+
+Multi-stage Docker build with `output: 'standalone'` in `next.config.ts`:
+
+1. **deps** — `npm ci` installs node_modules (cached layer)
+2. **builder** — `npm run build` with `NEXT_PUBLIC_API_URL` build arg
+3. **runner** — Copies standalone `server.js` + static assets, runs as non-root `nextjs` user
+
+Build context is `apps/web/` (not repo root), unlike the API Dockerfile which needs `shared/` and `data/`.
+
+### Environment Variables
+
+| Variable | Source | Injection |
+|----------|--------|-----------|
+| `NEXT_PUBLIC_API_URL` | `secrets.CREDIT_RISK_API_URL` | Docker build arg (inlined at build time) |
+
+No new GitHub secrets required — reuses `GCP_SA_KEY`, `GCP_PROJECT_ID`, `GCP_REGION`, and `CREDIT_RISK_API_URL` from the API deployment.
+
+### Free Tier Budget
+
+| Resource | Free Tier Allowance | Expected Usage |
+|----------|---------------------|----------------|
+| Cloud Run requests | 2M / month | < 1K / month |
+| Cloud Run vCPU | 180,000 s / month | < 200 s / month |
+| Cloud Run memory | 360,000 GiB-s / month | < 500 GiB-s / month |
+| Artifact Registry | 500 MB | ~200 MB (1 image) |
+
+Combined with the API service, total usage remains well within free tier.
+
+## Alternatives Considered
+
+- **Vercel** — Zero-config for Next.js, free preview deploys, no cold starts. However, Hobby plan is non-commercial only, and using Cloud Run keeps all infrastructure on a single platform (GCP). Vercel remains a viable fallback if cold starts become problematic.
+- **Cloudflare Pages** — Generous free tier but requires OpenNext adapter, 3 MB Worker size limit on free plan likely too small for Next.js + Recharts bundle.
+- **Netlify** — Good Next.js support via OpenNext adapter, but 300 build-minutes/month cap and credit-based pricing for new accounts add uncertainty.
+
+## Consequences
+
+- Cold starts of ~2-4 s when the container scales from zero (lighter than the API's ~5-10 s since there is no ML model loading)
+- `NEXT_PUBLIC_API_URL` is baked into the client bundle at build time; changing the API URL requires a redeploy of the web image
+- The web and API services are independently deployable — changes to `apps/web/` do not trigger an API redeploy, and vice versa
+- Future upgrade path: add `--min-instances=1` to eliminate cold starts (exits free tier, ~$5-10/mo for a lightweight Node.js container)


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile for `apps/web/` (deps → build → production) using `node:22-alpine` and `output: "standalone"`
- Add GitHub Actions workflow (`deploy-web-cloudrun.yml`) triggered on `apps/web/**` changes to main, mirroring the existing API deploy pattern
- Add ADR-011 documenting the Cloud Run hosting decision over Vercel, Cloudflare, and Netlify
- No new GitHub secrets required — reuses `GCP_SA_KEY`, `GCP_PROJECT_ID`, `GCP_REGION`, and `CREDIT_RISK_API_URL`

## Cloud Run Config

| Setting | Value |
|---------|-------|
| Memory | 512 Mi |
| CPU | 1 |
| Timeout | 60 s |
| Port | 3000 |
| Min instances | 0 (free tier) |
| Max instances | 2 |

## Test plan

- [ ] Verify CI passes (lint + build with `output: "standalone"`)
- [ ] Build Docker image locally: `docker build --build-arg NEXT_PUBLIC_API_URL=http://localhost:8000 -t credit-risk-web apps/web/`
- [ ] Run container: `docker run -p 3000:3000 credit-risk-web` — confirm middleware redirects and pages load
- [ ] After merge, trigger `workflow_dispatch` or push to verify Cloud Run deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)