### PR TITLE
fix(gradio): resolve Boruta feature selection timeout

### DIFF
--- a/apps/api/routers/feature_selection.py
+++ b/apps/api/routers/feature_selection.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 @router.post("/", response_model=FeatureSelectionResult)
 @limiter.limit("20/hour")
-async def select_features(
+def select_features(
     request: Request,
     fs_request: FeatureSelectionRequest,
     settings: Settings = Depends(get_settings),

--- a/apps/gradio/api_client.py
+++ b/apps/gradio/api_client.py
@@ -144,6 +144,7 @@ class CreditRiskAPI:
             f"{self.base_url}/feature-selection/",
             json=request,
             headers=self._headers(),
+            timeout=300.0,
         )
         response.raise_for_status()
         return response.json()

--- a/apps/gradio/components/training_tab.py
+++ b/apps/gradio/components/training_tab.py
@@ -330,6 +330,17 @@ def create_training_tab(api: CreditRiskAPI, training_results_state: gr.State) ->
                 None,
                 gr.update(visible=False),
             )
+        except httpx.TimeoutException:
+            logger.warning("Feature selection timed out")
+            return (
+                gr.update(
+                    visible=True,
+                    value="Feature selection timed out — try fewer iterations.",
+                ),
+                None,
+                None,
+                gr.update(visible=False),
+            )
         except Exception:
             logger.exception("Feature selection failed")
             return (

--- a/docs/1-ADRs/ADR-011-automatic-feature-selection.md
+++ b/docs/1-ADRs/ADR-011-automatic-feature-selection.md
@@ -72,6 +72,13 @@ Custom implementation to avoid adding the `BorutaPy` package. Algorithm:
 4. Repeat N iterations
 5. Apply `scipy.stats.binom.ppf` to classify each feature as Confirmed, Tentative, or Rejected
 
+**Performance note**: Each iteration trains a RandomForest(100 trees, max_depth=10) on a doubled feature matrix (real + shadow columns). With the full 26-feature dataset (7500 rows × 52 columns), this is the most compute-heavy method. Mitigations:
+
+- `n_jobs=-1` on the per-iteration RandomForest (parallel tree training)
+- Gradio client uses a 300-second timeout for the feature-selection endpoint (vs 60s default)
+- The API endpoint uses a synchronous `def` (not `async def`) so FastAPI runs it in a threadpool, avoiding event-loop blocking
+- The Gradio UI shows a specific timeout message ("try fewer iterations") rather than a generic failure
+
 ### Standardized Output
 
 ```json
@@ -131,7 +138,7 @@ Custom implementation to avoid adding the `BorutaPy` package. Algorithm:
 ### Negative
 
 - Adds `shap` dependency (~50 MB installed)
-- Boruta with high iteration count is compute-heavy (rate limited to 20/hour)
+- Boruta with high iteration count is compute-heavy (rate limited to 20/hour, mitigated with `n_jobs=-1` and extended client timeout)
 - WoE/IV binning may not be optimal for all feature distributions
 
 ### Future Enhancements

--- a/shared/logic/feature_selection.py
+++ b/shared/logic/feature_selection.py
@@ -359,6 +359,7 @@ def select_features_boruta(
         rf = RandomForestClassifier(
             n_estimators=100,
             max_depth=10,
+            n_jobs=-1,
             random_state=random_state + iteration,
         )
         rf.fit(X_combined, y)


### PR DESCRIPTION
## Summary

- **Root cause**: Boruta trains N RandomForests on a doubled feature matrix (7500 × 52). Even 30 iterations exceeds the 60s httpx client timeout, causing a generic "Feature selection failed." error
- Add `n_jobs=-1` to Boruta's RF for parallel tree training (~4-8x speedup)
- Increase feature-selection HTTP timeout to 300s
- Change API endpoint from `async def` to `def` (runs in threadpool, doesn't block event loop)
- Add `httpx.TimeoutException` handler with actionable "try fewer iterations" message
- Document performance mitigations in ADR-011

## Test plan

- [x] All 120 Python tests pass
- [x] Ruff lint clean
- [ ] Manual: run Gradio app, select Boruta with 30 iterations, verify it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)