### PR TITLE
docs(adr): add ADR governance, index, and fix numbering conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ git stash pop  # Restore changes later
 | `docs/0-RFCs/RFC-001-*.md` | Platform architecture |
 | `docs/0-RFCs/RFC-002-*.md` | API layer design |
 | `docs/0-RFCs/RFC-006-*.md` | Auth & security |
-| `docs/1-ADRs/` | Architecture decision records (ADR-001 through ADR-008) |
+| `docs/1-ADRs/` | Architecture decision records ([index](docs/1-ADRs/README.md)) |
 | `shared/schemas/loan.py` | Core data models |
 | `shared/logic/threshold.py` | Youden's J implementation |
 | `data/processed/cr_loan_w2.csv` | Training dataset (one-hot encoded) |
@@ -311,6 +311,48 @@ When Pydantic schemas in `shared/` change:
 3. Regenerate TS interfaces via `datamodel-code-generator` (see RFC-001 Q4)
 4. Update `apps/web/` components
 5. Verify `apps/gradio/` field mappings still match API contract
+
+## ADR Creation Checklist
+
+When creating a new Architecture Decision Record:
+
+### 1. Pick the next number
+
+```bash
+# Check the highest ADR number on main (not your branch)
+ls docs/1-ADRs/ADR-*.md | sort -V | tail -1
+```
+
+If working in a **worktree** or **parallel branch**, another branch may also be creating an ADR. To avoid numbering conflicts:
+
+- **Check open PRs** for new ADR files: `gh pr list --search "ADR" --state open`
+- **If a conflict is found at merge time**, renumber the later PR's ADR (higher number = later merge)
+- **Never reuse** a number that appeared in a merged PR, even if the file was later deleted
+
+### 2. Create the file
+
+File: `docs/1-ADRs/ADR-NNN-short-description.md`
+
+Required metadata table:
+
+```markdown
+# ADR-NNN: Title
+
+| Field | Value |
+|-------|-------|
+| Status | Proposed |
+| Author | Paul / Claude |
+| Date | YYYY-MM-DD |
+| PR | _Added before merge_ |
+```
+
+Status values: `Proposed` → `Accepted` → `Superseded` (or `Rejected`)
+
+### 3. Before merging the PR
+
+- [ ] Add the `| PR |` link to the ADR metadata table (use the PR number from `gh pr create`)
+- [ ] Add the new ADR to `docs/1-ADRs/README.md` index table
+- [ ] Verify no numbering conflict with other open/recently-merged PRs
 
 ## Do NOT
 

--- a/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
+++ b/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
@@ -5,6 +5,7 @@
 | Status | Proposed |
 | Author | Paul / Claude |
 | Date | 2026-02-07 |
+| PR | [#37](https://github.com/pkiage/tool-credit-risk-modelling/pull/37) |
 
 ## Context
 

--- a/docs/1-ADRs/ADR-012-automatic-feature-selection.md
+++ b/docs/1-ADRs/ADR-012-automatic-feature-selection.md
@@ -1,10 +1,11 @@
-# ADR-011: Automatic Feature Selection Methods
+# ADR-012: Automatic Feature Selection Methods
 
-| Field  | Value               |
-|--------|---------------------|
-| Status | Accepted            |
-| Author | Paul / Claude       |
-| Date   | 2026-02-07          |
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Author | Paul / Claude |
+| Date | 2026-02-07 |
+| PR | [#38](https://github.com/pkiage/tool-credit-risk-modelling/pull/38), [#39](https://github.com/pkiage/tool-credit-risk-modelling/pull/39) |
 
 ## Context
 

--- a/docs/1-ADRs/README.md
+++ b/docs/1-ADRs/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Credit Risk Platform.
+
+## Index
+
+| ADR | Title | Status | Date | PR |
+|-----|-------|--------|------|----|
+| [ADR-001](ADR-001-shared-layer-foundation.md) | Shared Layer Foundation | Accepted | 2025-01-31 | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
+| [ADR-002](ADR-002-pydantic-as-contract.md) | Pydantic as Contract Layer | Accepted | 2026-02-02 | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
+| [ADR-003](ADR-003-marimo-over-jupyter.md) | Marimo over Jupyter | Accepted | 2026-02-02 | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
+| [ADR-004](ADR-004-api-key-authentication.md) | API Key Authentication | Accepted | 2026-02-02 | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
+| [ADR-005](ADR-005-model-persistence-strategy.md) | Model Persistence Strategy | Accepted | 2026-02-02 | [#19](https://github.com/pkiage/tool-credit-risk-modelling/pull/19) |
+| [ADR-006](ADR-006-ui-progression.md) | UI Progression (Marimo, Gradio, Next.js) | Accepted | 2026-02-01 | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
+| [ADR-007](ADR-007-chart-library.md) | Chart Library (Recharts) | Accepted | 2026-02-02 | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
+| [ADR-008](ADR-008-monorepo-structure.md) | Monorepo Structure | Accepted | 2026-02-02 | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
+| [ADR-009](ADR-009-cloud-run-deployment.md) | Cloud Run Deployment | Accepted | 2026-02-07 | [#30](https://github.com/pkiage/tool-credit-risk-modelling/pull/30) |
+| [ADR-010](ADR-010-feature-selection.md) | Training Feature Selection | Accepted | 2026-02-07 | [#31](https://github.com/pkiage/tool-credit-risk-modelling/pull/31) |
+| [ADR-011](ADR-011-nextjs-cloud-run.md) | Next.js Deployment on Cloud Run | Proposed | 2026-02-07 | [#37](https://github.com/pkiage/tool-credit-risk-modelling/pull/37) |
+| [ADR-012](ADR-012-automatic-feature-selection.md) | Automatic Feature Selection Methods | Accepted | 2026-02-07 | [#38](https://github.com/pkiage/tool-credit-risk-modelling/pull/38), [#39](https://github.com/pkiage/tool-credit-risk-modelling/pull/39) |
+
+## Creating a New ADR
+
+See the [ADR Creation Checklist](../../CLAUDE.md#adr-creation-checklist) in CLAUDE.md.


### PR DESCRIPTION
## Summary

- **Fix ADR-011 numbering conflict**: Two worktrees independently created `ADR-011-*` files. Renumbered automatic-feature-selection to ADR-012 (PR #38 merged after PR #37)
- **Add PR links** to ADR-011 and ADR-012 metadata tables (were the only ADRs missing them)
- **Create `docs/1-ADRs/README.md`**: Central index table of all 12 ADRs with links, status, date, and PRs
- **Add ADR Creation Checklist to CLAUDE.md**: Numbering protocol (check main + open PRs), metadata template, and pre-merge checklist to prevent future worktree conflicts

## Test plan

- [ ] Verify all ADR file links in `docs/1-ADRs/README.md` resolve correctly on GitHub
- [ ] Confirm no duplicate ADR numbers exist (`ls docs/1-ADRs/ADR-*.md | sort`)
- [ ] Review ADR Creation Checklist in CLAUDE.md for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)