### PR TITLE
fix(marimo): add landing page at root and HF Spaces link

### DIFF
--- a/apps/marimo/README.md
+++ b/apps/marimo/README.md
@@ -10,10 +10,13 @@ pinned: false
 
 Interactive Marimo notebooks for exploring credit risk model training, evaluation, and threshold optimization.
 
+**Live Demo**: [huggingface.co/spaces/pkiage/credit-risk-notebooks](https://huggingface.co/spaces/pkiage/credit-risk-notebooks)
+
 ## Notebooks
 
 | Route | Notebook | Description |
 | ----- | -------- | ----------- |
+| `/` | Landing Page | Navigation and overview of all notebooks |
 | `/01_eda` | Exploratory Data Analysis | Dataset overview, distributions, correlations |
 | `/02_model_comparison` | Model Comparison | Train and compare Logistic Regression, XGBoost, Random Forest |
 | `/03_threshold_optimization` | Threshold Optimization | Interactive threshold tuning with Youden's J |

--- a/apps/marimo/server.py
+++ b/apps/marimo/server.py
@@ -12,8 +12,16 @@ _candidates = [_here / "notebooks", _here.parent.parent / "notebooks"]
 notebooks_dir = next((d for d in _candidates if d.is_dir()), _candidates[0])
 
 server = marimo.create_asgi_app(quiet=True, include_code=True)
+
+# Mount landing page at root
+landing_page = notebooks_dir / "00_landing.py"
+if landing_page.exists():
+    server = server.with_app(path="/", root=str(landing_page))
+
+# Mount other notebooks at their respective paths
 for nb in sorted(notebooks_dir.glob("*.py")):
-    server = server.with_app(path=f"/{nb.stem}", root=str(nb))
+    if nb.stem != "00_landing":  # Skip landing page (already mounted at root)
+        server = server.with_app(path=f"/{nb.stem}", root=str(nb))
 
 app = server.build()
 

--- a/notebooks/00_landing.py
+++ b/notebooks/00_landing.py
@@ -24,7 +24,8 @@ def _(mo):
         """
         # Credit Risk Modeling Platform
 
-        Interactive notebooks for exploring credit risk data, training models, and optimizing decision thresholds.
+        Interactive notebooks for exploring credit risk data, training models,
+        and optimizing decision thresholds.
         """
     )
     return
@@ -37,16 +38,23 @@ def _(mo):
         ## Notebooks
 
         ### [📊 Exploratory Data Analysis](/01_eda)
-        Dataset overview, feature distributions, correlation analysis, and target variable exploration.
+        Dataset overview, feature distributions, correlation analysis,
+        and target variable exploration.
 
         ### [🤖 Model Comparison](/02_model_comparison)
-        Train and compare multiple classification models (Logistic Regression, XGBoost, Random Forest) side-by-side with ROC curves and feature importance.
+        Train and compare multiple classification models
+        (Logistic Regression, XGBoost, Random Forest) side-by-side
+        with ROC curves and feature importance.
 
         ### [⚖️ Threshold Optimization](/03_threshold_optimization)
-        Interactive threshold tuning using Youden's J statistic with sensitivity vs specificity trade-offs and cost-based optimization.
+        Interactive threshold tuning using Youden's J statistic
+        with sensitivity vs specificity trade-offs
+        and cost-based optimization.
 
         ### [📈 Probability Calibration](/04_calibration)
-        Evaluate model calibration with reliability diagrams, Brier scores, and compare sigmoid vs isotonic calibration methods.
+        Evaluate model calibration with reliability diagrams,
+        Brier scores, and compare sigmoid vs isotonic
+        calibration methods.
         """
     )
     return

--- a/notebooks/00_landing.py
+++ b/notebooks/00_landing.py
@@ -1,0 +1,68 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.19.7"
+app = marimo.App(width="medium", app_title="Credit Risk Platform")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Credit Risk Modeling Platform
+
+        Interactive notebooks for exploring credit risk data, training models, and optimizing decision thresholds.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Notebooks
+
+        ### [📊 Exploratory Data Analysis](/01_eda)
+        Dataset overview, feature distributions, correlation analysis, and target variable exploration.
+
+        ### [🤖 Model Comparison](/02_model_comparison)
+        Train and compare multiple classification models (Logistic Regression, XGBoost, Random Forest) side-by-side with ROC curves and feature importance.
+
+        ### [⚖️ Threshold Optimization](/03_threshold_optimization)
+        Interactive threshold tuning using Youden's J statistic with sensitivity vs specificity trade-offs and cost-based optimization.
+
+        ### [📈 Probability Calibration](/04_calibration)
+        Evaluate model calibration with reliability diagrams, Brier scores, and compare sigmoid vs isotonic calibration methods.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ---
+
+        **Live Demo**: [huggingface.co/spaces/pkiage/credit-risk-notebooks](https://huggingface.co/spaces/pkiage/credit-risk-notebooks)
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Fixes the "Not Found" error when visiting the HF Spaces base URL by adding a landing page notebook at the root path.

- Create `notebooks/00_landing.py` with navigation links to all 4 analysis notebooks
- Update `apps/marimo/server.py` to mount landing page at `path="/"`
- Update `apps/marimo/README.md` with live HF Spaces link

## Problem

The HF Spaces deployment (https://huggingface.co/spaces/pkiage/credit-risk-notebooks) was showing "Not Found" at the root URL because the multi-notebook server only had routes at `/01_eda`, `/02_model_comparison`, `/03_threshold_optimization`, and `/04_calibration`.

## Solution

Created a professional landing page notebook that:
- Provides navigation to all 4 notebooks
- Includes descriptions of each notebook's purpose
- Links to the live HF Spaces demo
- Serves as the root `/` route

## Files Changed

| File | Action | Purpose |
| ---- | ------ | ------- |
| `notebooks/00_landing.py` | Create | Landing page with navigation and notebook descriptions |
| `apps/marimo/server.py` | Edit | Mount landing page at root, skip from auto-discovery loop |
| `apps/marimo/README.md` | Edit | Add live HF Spaces link and document root route |

## Test Plan

- [ ] GitHub Actions workflow passes
- [ ] HF Spaces redeploys successfully
- [ ] Root URL shows landing page (not 404)
- [ ] All notebook links work from landing page
- [ ] Direct URLs to notebooks still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)