### PR TITLE
fix(marimo): add tabulate dependency for pandas to_markdown

### DIFF
--- a/apps/marimo/requirements.txt
+++ b/apps/marimo/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn>=1.5
 xgboost>=2.1
 plotly>=5.22
 pydantic>=2.7
+tabulate>=0.9


### PR DESCRIPTION
## Summary

Add missing `tabulate` dependency required by `pandas.DataFrame.to_markdown()`.

## Problem

The dataset overview section in the EDA notebook was failing silently because `pandas.DataFrame.to_markdown()` requires the `tabulate` package, which wasn't in `requirements.txt`.

This caused the marimo cell at `notebooks/01_eda.py:86-112` to error when trying to format the data types table, resulting in missing dataset statistics on the deployed HF Space.

## Fix

Add `tabulate>=0.9` to `apps/marimo/requirements.txt`.

## Impact

Once deployed, the EDA notebook will show:
- Dataset shape (rows, columns)
- Missing values count
- Default rate
- Non-default/Default counts
- Data types breakdown table

## Test Plan

- [ ] GitHub Actions passes
- [ ] HF Spaces redeploys with tabulate
- [ ] Dataset overview stats table appears in `/01_eda`
- [ ] No more internal errors in marimo

🤖 Generated with [Claude Code](https://claude.com/claude-code)