### PR TITLE
docs: update deployment docs to reflect Cloud Run implementation

### DIFF
--- a/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
+++ b/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
@@ -293,7 +293,7 @@ marimo run notebooks/02_model_comparison.py
 
 - HF Spaces deployment (Gradio)
 - Molab deployment (Marimo)
-- Vercel deployment (Next.js)
+- Cloud Run deployment (Next.js, FastAPI)
 
 ## Engineering Impact
 
@@ -316,8 +316,7 @@ marimo run notebooks/02_model_comparison.py
 | Local | All | `uv run`, `npm run dev` |
 | Molab | Marimo | Notebook deployment |
 | HF Spaces | Gradio | Docker-based |
-| Vercel | Next.js | Edge deployment |
-| Any cloud | FastAPI | Containerized |
+| Cloud Run | Next.js, FastAPI | Containerized, scales to zero |
 
 ## Best Practices
 

--- a/docs/0-RFCs/RFC-006-auth-polish.md
+++ b/docs/0-RFCs/RFC-006-auth-polish.md
@@ -141,7 +141,7 @@ CORS_ORIGINS_DEV = ["*"]
 CORS_ORIGINS_PROD = [
     "https://your-domain.com",
     "https://www.your-domain.com",
-    "https://your-app.vercel.app",
+    "https://your-app.run.app",
 ]
 
 app.add_middleware(
@@ -327,7 +327,7 @@ async def credit_risk_exception_handler(request: Request, exc: CreditRiskExcepti
 
 - Installation instructions
 - Configuration guide
-- Deployment guide (Vercel, HF Spaces, Docker)
+- Deployment guide (Cloud Run, HF Spaces, Docker)
 - API usage examples
 - Contributing guidelines
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,54 +48,180 @@ uv run uvicorn apps.api.main:app --reload
 
 ### API
 
-```dockerfile
-FROM python:3.12-slim
+The API uses a multi-stage Dockerfile at the repository root:
 
-WORKDIR /app
-COPY . .
-RUN pip install uv && uv sync --extra api
+```bash
+# Build API image
+docker build -t credit-risk-api .
 
-EXPOSE 8000
-CMD ["uv", "run", "uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run API container
+docker run -p 8080:8080 \
+  -e CREDIT_RISK_REQUIRE_AUTH=true \
+  -e CREDIT_RISK_API_KEYS=your-api-key \
+  credit-risk-api
 ```
+
+See `Dockerfile` in the repository root for the full build configuration.
+
+### Web (Next.js)
+
+The web app uses a multi-stage Dockerfile in `apps/web/`:
+
+```bash
+# Build web image
+cd apps/web
+docker build \
+  --build-arg NEXT_PUBLIC_API_URL=http://localhost:8080 \
+  -t credit-risk-web .
+
+# Run web container
+docker run -p 3000:3000 credit-risk-web
+```
+
+See `apps/web/Dockerfile` for the full build configuration.
 
 ### Docker Compose
 
+Example `docker-compose.yml` for running both services:
+
 ```yaml
-version: "3.8"
 services:
   api:
     build: .
     ports:
-      - "8000:8000"
+      - "8080:8080"
     environment:
-      - CREDIT_RISK_REQUIRE_AUTH=true
-      - CREDIT_RISK_API_KEYS=${API_KEYS}
+      - CREDIT_RISK_REQUIRE_AUTH=false
       - CREDIT_RISK_CORS_ORIGINS=http://localhost:3000
+    volumes:
+      - ./data:/app/data
+      - ./artifacts:/app/artifacts
 
   web:
-    build: ./apps/web
+    build:
+      context: ./apps/web
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8080
     ports:
       - "3000:3000"
-    environment:
-      - NEXT_PUBLIC_API_URL=http://api:8000
     depends_on:
       - api
 ```
 
-## Vercel Deployment (Next.js)
+**Note:** `NEXT_PUBLIC_API_URL` must be accessible from the browser (use `http://localhost:8080`, not `http://api:8080`).
 
-1. Connect repo to Vercel
-2. Set root directory to `apps/web`
-3. Add environment variable: `NEXT_PUBLIC_API_URL` = your API URL
-4. Deploy
+## Cloud Run Deployment
+
+Both the FastAPI backend and Next.js frontend are deployed to Google Cloud Run with automated CI/CD via GitHub Actions.
+
+### Prerequisites
+
+- GCP project with Cloud Run and Artifact Registry enabled
+- Service account with necessary permissions
+- GitHub repository secrets configured:
+  - `GCP_SA_KEY` - Service account JSON key
+  - `GCP_PROJECT_ID` - GCP project ID
+  - `GCP_REGION` - Deployment region (e.g., `us-central1`)
+  - `CREDIT_RISK_API_URL` - Production API URL for web app
+  - (Optional) `CREDIT_RISK_API_KEYS` - API keys for authentication
+
+### API Deployment
+
+Automatically deploys when changes are pushed to `main` branch affecting:
+
+- `apps/api/**`
+- `shared/**`
+- `Dockerfile`
+- `pyproject.toml`
+- `uv.lock`
+
+Workflow: `.github/workflows/deploy-api-cloudrun.yml`
+
+**Service Configuration:**
+
+- Memory: 1 GiB
+- CPU: 1
+- Timeout: 300s
+- Port: 8080
+- Min instances: 0 (scales to zero)
+
+**Production URL:** Available via Cloud Run service URL
+
+### Web Deployment (Next.js)
+
+Automatically deploys when changes are pushed to `main` branch affecting `apps/web/**`.
+
+Workflow: `.github/workflows/deploy-web-cloudrun.yml`
+
+**Service Configuration:**
+
+- Memory: 512 MiB
+- CPU: 1
+- Timeout: 60s
+- Port: 3000
+- Min instances: 0 (scales to zero)
+- Max instances: 2
+
+**Production URL:** [https://credit-risk-web-p24vtxpm5q-uc.a.run.app](https://credit-risk-web-p24vtxpm5q-uc.a.run.app)
+
+See [ADR-011](../docs/1-ADRs/ADR-011-nextjs-cloud-run.md) for deployment architecture details.
+
+### Manual Cloud Run Deployment
+
+```bash
+# Build and deploy API
+gcloud builds submit --tag gcr.io/PROJECT_ID/credit-risk-api
+gcloud run deploy credit-risk-api \
+  --image gcr.io/PROJECT_ID/credit-risk-api \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated
+
+# Build and deploy Web
+cd apps/web
+docker build \
+  --build-arg NEXT_PUBLIC_API_URL=https://your-api-url.run.app \
+  -t gcr.io/PROJECT_ID/credit-risk-web .
+docker push gcr.io/PROJECT_ID/credit-risk-web
+
+gcloud run deploy credit-risk-web \
+  --image gcr.io/PROJECT_ID/credit-risk-web \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --memory 512Mi \
+  --port 3000
+```
 
 ## HF Spaces Deployment (Gradio)
 
+The Gradio demo app is deployed to Hugging Face Spaces with automated sync via GitHub Actions.
+
+**Live demo:** [huggingface.co/spaces/pkiage/credit_risk_modeling_demo](https://huggingface.co/spaces/pkiage/credit_risk_modeling_demo)
+
+### Automated Deployment
+
+Workflow: `.github/workflows/sync_to_hf_hub.yml`
+
+Automatically syncs when changes are pushed to `main` branch affecting:
+
+- `apps/gradio/**`
+- `shared/**`
+
+Requires GitHub secret `HF_TOKEN` with write access to the Space.
+
+### Manual HF Spaces Setup
+
 1. Create a new Space on Hugging Face
-2. Set SDK to Gradio
+2. Set SDK to Gradio (Python 3.12)
 3. Add environment variable: `CREDIT_RISK_API_URL` = your API URL
-4. Push `apps/gradio/` to the Space repo
+4. Push `apps/gradio/` contents to the Space repo:
+
+```bash
+cd apps/gradio
+git remote add hf https://huggingface.co/spaces/USERNAME/SPACE_NAME
+git push hf main
+```
 
 ## Production Checklist
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,14 +1,48 @@
 # Environment Variables
 
+## Application Variables
+
 | Variable | Layer | Required | Default | Description |
 |----------|-------|----------|---------|-------------|
 | `CREDIT_RISK_APP_NAME` | api | No | `Credit Risk API` | Application name |
-| `CREDIT_RISK_DEBUG` | api | No | `false` | Enable debug mode |
+| `CREDIT_RISK_DEBUG` | api | No | `false` | Enable debug mode (set to `false` in production) |
 | `CREDIT_RISK_DEFAULT_DATASET_PATH` | api | No | `data/processed/cr_loan_w2.csv` | Path to default training dataset |
 | `CREDIT_RISK_MODEL_ARTIFACTS_PATH` | api | No | `artifacts/` | Directory for persisted model artifacts |
 | `CREDIT_RISK_LOG_LEVEL` | api | No | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
-| `CREDIT_RISK_CORS_ORIGINS` | api | No | `*` | Comma-separated allowed CORS origins |
-| `CREDIT_RISK_REQUIRE_AUTH` | api | No | `false` | Enable API key authentication |
-| `CREDIT_RISK_API_KEYS` | api | If auth enabled | — | Comma-separated API keys |
+| `CREDIT_RISK_CORS_ORIGINS` | api | No | `*` | Comma-separated allowed CORS origins (restrict in production) |
+| `CREDIT_RISK_REQUIRE_AUTH` | api | No | `false` | Enable API key authentication (set to `true` in production) |
+| `CREDIT_RISK_API_KEYS` | api | If auth enabled | — | Comma-separated API keys (required if auth enabled) |
 | `CREDIT_RISK_API_URL` | gradio | No | `http://localhost:8000` | API base URL for Gradio app |
-| `NEXT_PUBLIC_API_URL` | web | No | `http://localhost:8000` | API URL for browser requests |
+| `NEXT_PUBLIC_API_URL` | web | No | `http://localhost:8000` | API URL for browser requests (baked into client bundle at build time) |
+
+## Deployment-Specific Notes
+
+### Google Cloud Run (API & Web)
+
+**API Service:**
+
+- All `CREDIT_RISK_*` variables are set as Cloud Run environment variables
+- Production uses Cloud Run's built-in HTTPS (no separate reverse proxy needed)
+- Default port is 8080 (automatically set by Cloud Run)
+
+**Web Service:**
+
+- `NEXT_PUBLIC_API_URL` is passed as a Docker build arg during GitHub Actions workflow
+- The value is inlined into the client bundle at build time
+- Changing this value requires rebuilding and redeploying the web image
+
+### Hugging Face Spaces (Gradio)
+
+- Only requires `CREDIT_RISK_API_URL` to point to the deployed API
+- Set via Space settings or `.env` file in the Space repo
+- HF Spaces automatically provides HTTPS endpoints
+
+## Production Recommendations
+
+| Variable | Production Value |
+|----------|------------------|
+| `CREDIT_RISK_DEBUG` | `false` |
+| `CREDIT_RISK_REQUIRE_AUTH` | `true` |
+| `CREDIT_RISK_API_KEYS` | Strong random keys (e.g., `openssl rand -hex 32`) |
+| `CREDIT_RISK_CORS_ORIGINS` | Specific domains only (e.g., `https://your-app.run.app`) |
+| `NEXT_PUBLIC_API_URL` | Your Cloud Run API URL (e.g., `https://credit-risk-api-xxx.run.app`) |


### PR DESCRIPTION
## Summary

- Update DEPLOYMENT.md to replace Vercel references with actual Cloud Run deployment
- Add detailed Cloud Run configuration for both API and Web services
- Document GitHub Actions workflows for automated deployment
- Enhance ENV_VARS.md with deployment-specific notes and production recommendations
- Update RFC-001 and RFC-006 to reflect Cloud Run usage
- Improve Docker examples with correct ports (8080 for API, 3000 for Web)

## Changes

### DEPLOYMENT.md
- **Removed:** Generic Vercel deployment section
- **Added:** Comprehensive Cloud Run deployment section with:
  - Prerequisites and GitHub secrets configuration
  - API and Web service configurations
  - Automated deployment via GitHub Actions
  - Manual deployment commands
- **Updated:** Docker examples to reference actual Dockerfiles
- **Enhanced:** HF Spaces section with live demo link and workflow details

### ENV_VARS.md
- **Added:** Deployment-specific notes section
  - Cloud Run configuration details
  - HF Spaces configuration
  - Production recommendations table
- **Enhanced:** Variable descriptions with production guidance

### RFCs
- **RFC-001:** Updated platform table to show Cloud Run instead of Vercel
- **RFC-006:** Updated CORS example and deployment guide references

## Test Plan

- [x] All documentation files render correctly in markdown
- [x] Links to ADR-011, workflows, and live demos are valid
- [x] Environment variables match actual implementation in `apps/api/config.py`
- [x] Docker commands reference existing Dockerfiles
- [x] No broken Vercel references remain (except in ADR-011 alternatives section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)