### PR TITLE
fix(web): add trailing slashes to API endpoint paths

### DIFF
--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -72,7 +72,7 @@ export const api = {
 	},
 
 	train: async (config: TrainingConfig): Promise<TrainingResult> => {
-		return request<TrainingResult>("/train", {
+		return request<TrainingResult>("/train/", {
 			method: "POST",
 			body: JSON.stringify(config),
 			timeout: TRAINING_TIMEOUT,
@@ -80,14 +80,14 @@ export const api = {
 	},
 
 	predict: async (requestBody: PredictionRequest): Promise<PredictionResponse> => {
-		return request<PredictionResponse>("/predict", {
+		return request<PredictionResponse>("/predict/", {
 			method: "POST",
 			body: JSON.stringify(requestBody),
 		});
 	},
 
 	listModels: async (): Promise<ModelMetadata[]> => {
-		return request<ModelMetadata[]>("/models");
+		return request<ModelMetadata[]>("/models/");
 	},
 
 	getModel: async (modelId: string): Promise<ModelMetadata> => {


### PR DESCRIPTION
## Summary
- Adds trailing slashes to `/train/`, `/predict/`, and `/models/` paths in the web API client
- Fixes browser fetch failing with "Cannot reach API" error on the deployed Cloud Run web app

## Root Cause
FastAPI's `redirect_slashes` (default: `true`) issues a **307 redirect** from `/train` → `/train/`. Because Cloud Run terminates TLS at the load balancer, the redirect URL uses `http://` instead of `https://`. Browsers block this HTTPS→HTTP downgrade as mixed content, causing `fetch` to throw a `TypeError`.

The Gradio app on HF Spaces was unaffected because Python HTTP clients follow redirects without enforcing mixed-content rules.

## Changes
- `apps/web/lib/api-client.ts`: Added trailing slashes to 3 endpoint paths (`/train/`, `/predict/`, `/models/`) that are mounted via FastAPI router prefixes with `@router.post("/")`

## Test plan
- [ ] Deploy to Cloud Run and verify the Train page successfully calls the API
- [ ] Verify Predict and Models pages also work
- [ ] Confirm local dev (`localhost:8000`) still works with trailing slashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)