### PR TITLE
fix(web): dark mode WCAG AAA color contrast

### DIFF
--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -154,7 +154,7 @@ export default function ComparePage() {
 	if (modelsLoading) {
 		return (
 			<div className="flex items-center justify-center py-12">
-				<p className="text-gray-500">Loading models...</p>
+				<p className="text-foreground-muted">Loading models...</p>
 			</div>
 		);
 	}
@@ -162,11 +162,11 @@ export default function ComparePage() {
 	if (models.length === 0) {
 		return (
 			<div className="space-y-4">
-				<h1 className="text-2xl font-bold text-gray-900">Compare Models</h1>
+				<h1 className="text-2xl font-bold text-foreground">Compare Models</h1>
 				<Card>
 					<div className="py-8 text-center">
-						<p className="text-gray-500">No trained models available.</p>
-						<p className="mt-2 text-sm text-gray-400">
+						<p className="text-foreground-muted">No trained models available.</p>
+						<p className="mt-2 text-sm text-foreground-muted">
 							Train some models first, then come back to compare them.
 						</p>
 					</div>
@@ -178,12 +178,14 @@ export default function ComparePage() {
 	return (
 		<div className="space-y-8">
 			<div>
-				<h1 className="text-2xl font-bold text-gray-900">Compare Models</h1>
-				<p className="mt-1 text-gray-600">Select models to compare their performance metrics.</p>
+				<h1 className="text-2xl font-bold text-foreground">Compare Models</h1>
+				<p className="mt-1 text-foreground-secondary">
+					Select models to compare their performance metrics.
+				</p>
 			</div>
 
 			{error && (
-				<div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+				<div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 p-4 text-sm text-red-800 dark:text-red-200">
 					{error}
 				</div>
 			)}
@@ -193,34 +195,42 @@ export default function ComparePage() {
 					{models.map((model) => (
 						<label
 							key={model.model_id}
-							className="flex cursor-pointer items-center gap-3 rounded-md border border-gray-100 px-4 py-2 hover:bg-gray-50"
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-border px-4 py-2 hover:bg-surface"
 						>
 							<input
 								type="checkbox"
-								className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+								className="h-4 w-4 rounded border-border-strong text-primary focus:ring-focus-ring"
 								checked={selectedIds.has(model.model_id)}
 								onChange={() => toggleModel(model.model_id)}
 							/>
 							<div className="flex-1">
-								<span className="font-medium text-gray-900">{model.model_type}</span>
-								<span className="ml-2 text-sm text-gray-500">{model.model_id.slice(0, 8)}</span>
+								<span className="font-medium text-foreground">
+									{model.model_type}
+								</span>
+								<span className="ml-2 text-sm text-foreground-muted">
+									{model.model_id.slice(0, 8)}
+								</span>
 							</div>
 							<div className="text-right text-sm">
-								<span className="text-gray-600">AUC: {model.roc_auc.toFixed(3)}</span>
-								<span className="ml-3 text-gray-400">{formatTimestamp(model.created_at)}</span>
+								<span className="text-foreground-secondary">
+									AUC: {model.roc_auc.toFixed(3)}
+								</span>
+								<span className="ml-3 text-foreground-muted">
+									{formatTimestamp(model.created_at)}
+								</span>
 							</div>
 						</label>
 					))}
 				</div>
 
 				<div className="mt-4 flex items-center gap-4">
-					<div className="flex rounded-lg border border-gray-200">
+					<div className="flex rounded-lg border border-border">
 						<button
 							type="button"
 							className={`rounded-l-lg px-3 py-1.5 text-sm font-medium transition-colors ${
 								mode === "stored"
-									? "bg-blue-600 text-white"
-									: "bg-white text-gray-700 hover:bg-gray-50"
+									? "bg-primary text-primary-foreground"
+									: "bg-background text-foreground-secondary hover:bg-surface"
 							}`}
 							onClick={() => setMode("stored")}
 						>
@@ -228,10 +238,10 @@ export default function ComparePage() {
 						</button>
 						<button
 							type="button"
-							className={`rounded-r-lg border-l border-gray-200 px-3 py-1.5 text-sm font-medium transition-colors ${
+							className={`rounded-r-lg border-l border-border px-3 py-1.5 text-sm font-medium transition-colors ${
 								mode === "retrain"
-									? "bg-blue-600 text-white"
-									: "bg-white text-gray-700 hover:bg-gray-50"
+									? "bg-primary text-primary-foreground"
+									: "bg-background text-foreground-secondary hover:bg-surface"
 							}`}
 							onClick={() => setMode("retrain")}
 						>
@@ -247,19 +257,20 @@ export default function ComparePage() {
 				</div>
 
 				{mode === "stored" && (
-					<p className="mt-2 text-xs text-gray-400">
+					<p className="mt-2 text-xs text-foreground-muted">
 						Uses metrics from original training. Results may not be available for older models.
 					</p>
 				)}
 				{mode === "retrain" && (
-					<p className="mt-2 text-xs text-gray-400">
-						Re-trains each model type with default config. Creates new models with fresh metrics.
+					<p className="mt-2 text-xs text-foreground-muted">
+						Re-trains each model type with default config. Creates new models with fresh
+						metrics.
 					</p>
 				)}
 			</Card>
 
 			{unavailableIds.size > 0 && (
-				<div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+				<div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 p-4 text-sm text-amber-800 dark:text-amber-200">
 					Stored results unavailable for{" "}
 					{Array.from(unavailableIds)
 						.map((id) => id.slice(0, 8))

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -204,17 +204,13 @@ export default function ComparePage() {
 								onChange={() => toggleModel(model.model_id)}
 							/>
 							<div className="flex-1">
-								<span className="font-medium text-foreground">
-									{model.model_type}
-								</span>
+								<span className="font-medium text-foreground">{model.model_type}</span>
 								<span className="ml-2 text-sm text-foreground-muted">
 									{model.model_id.slice(0, 8)}
 								</span>
 							</div>
 							<div className="text-right text-sm">
-								<span className="text-foreground-secondary">
-									AUC: {model.roc_auc.toFixed(3)}
-								</span>
+								<span className="text-foreground-secondary">AUC: {model.roc_auc.toFixed(3)}</span>
 								<span className="ml-3 text-foreground-muted">
 									{formatTimestamp(model.created_at)}
 								</span>
@@ -263,8 +259,7 @@ export default function ComparePage() {
 				)}
 				{mode === "retrain" && (
 					<p className="mt-2 text-xs text-foreground-muted">
-						Re-trains each model type with default config. Creates new models with fresh
-						metrics.
+						Re-trains each model type with default config. Creates new models with fresh metrics.
 					</p>
 				)}
 			</Card>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -84,32 +84,32 @@
 	--surface: #171717;
 	--surface-elevated: #262626;
 
-	/* Foregrounds - enhanced contrast for dark mode */
+	/* Foregrounds - WCAG AAA (7:1 on surface-elevated) */
 	--foreground: #fafafa;
 	--foreground-secondary: #d4d4d4;
-	--foreground-muted: #a3a3a3;
+	--foreground-muted: #c0c0c0;
 
-	/* Borders */
-	--border: #404040;
-	--border-strong: #525252;
+	/* Borders - 3:1+ on background (SC 1.4.11) */
+	--border: #666666;
+	--border-strong: #7a7a7a;
 
-	/* Primary (Blue) - brighter for dark backgrounds */
-	--primary: #3b82f6;
-	--primary-hover: #60a5fa;
-	--primary-active: #2563eb;
-	--primary-foreground: #ffffff;
+	/* Primary (Blue) - 7.8:1 on background, dark fg for AAA on bright bg */
+	--primary: #60a5fa;
+	--primary-hover: #93c5fd;
+	--primary-active: #3b82f6;
+	--primary-foreground: #000000;
 
-	/* Danger (Red) - adjusted for dark mode */
-	--danger: #ef4444;
-	--danger-hover: #f87171;
-	--danger-foreground: #ffffff;
+	/* Danger (Red) - 7.2:1 on background */
+	--danger: #f87171;
+	--danger-hover: #fca5a5;
+	--danger-foreground: #000000;
 
-	/* Success (Green) - adjusted for dark mode */
+	/* Success (Green) - 7.8:1 on background */
 	--success: #10b981;
 	--success-hover: #34d399;
-	--success-foreground: #ffffff;
+	--success-foreground: #000000;
 
-	/* Warning (Orange) - adjusted for dark mode */
+	/* Warning (Orange) - 9.2:1 on background */
 	--warning: #f59e0b;
 	--warning-hover: #fbbf24;
 	--warning-foreground: #000000;
@@ -122,7 +122,7 @@
 	--chart-5: #fbbf24; /* Orange */
 
 	/* Focus ring */
-	--focus-ring: #60a5fa;
+	--focus-ring: #93c5fd;
 }
 
 body {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -43,21 +43,23 @@ export default function Home() {
 	return (
 		<div className="space-y-8">
 			<div>
-				<h1 className="text-3xl font-bold text-gray-900">Credit Risk Platform</h1>
-				<p className="mt-2 text-gray-600">Train, evaluate, and deploy credit risk models.</p>
+				<h1 className="text-3xl font-bold text-foreground">Credit Risk Platform</h1>
+				<p className="mt-2 text-foreground-secondary">
+					Train, evaluate, and deploy credit risk models.
+				</p>
 			</div>
 
 			<div className="flex items-center gap-2">
 				<span
 					className={`inline-block h-3 w-3 rounded-full ${
-						healthy === null ? "bg-gray-300" : healthy ? "bg-green-500" : "bg-red-500"
+						healthy === null ? "bg-foreground-muted" : healthy ? "bg-green-500" : "bg-red-500"
 					}`}
 				/>
-				<span className="text-sm text-gray-600">
+				<span className="text-sm text-foreground-secondary">
 					API: {healthy === null ? "Checking..." : healthy ? "Connected" : "Unavailable"}
 				</span>
 				{models.length > 0 && (
-					<span className="ml-4 text-sm text-gray-600">
+					<span className="ml-4 text-sm text-foreground-secondary">
 						{models.length} model{models.length !== 1 ? "s" : ""} trained
 					</span>
 				)}
@@ -67,8 +69,8 @@ export default function Home() {
 				{pages.map((page) => (
 					<Link key={page.href} href={page.href}>
 						<Card className="h-full transition-shadow hover:shadow-md">
-							<h2 className="text-lg font-semibold text-gray-900">{page.title}</h2>
-							<p className="mt-2 text-sm text-gray-600">{page.description}</p>
+							<h2 className="text-lg font-semibold text-foreground">{page.title}</h2>
+							<p className="mt-2 text-sm text-foreground-secondary">{page.description}</p>
 						</Card>
 					</Link>
 				))}
@@ -80,13 +82,13 @@ export default function Home() {
 						{models.map((model) => (
 							<div
 								key={model.model_id}
-								className="flex items-center justify-between rounded-md border border-gray-100 px-4 py-2"
+								className="flex items-center justify-between rounded-md border border-border px-4 py-2"
 							>
 								<div>
-									<span className="font-medium text-gray-900">{model.model_type}</span>
-									<span className="ml-2 text-sm text-gray-500">{model.model_id}</span>
+									<span className="font-medium text-foreground">{model.model_type}</span>
+									<span className="ml-2 text-sm text-foreground-muted">{model.model_id}</span>
 								</div>
-								<div className="text-sm text-gray-600">
+								<div className="text-sm text-foreground-secondary">
 									AUC: {model.roc_auc.toFixed(3)} | Acc: {model.accuracy.toFixed(3)}
 								</div>
 							</div>

--- a/apps/web/app/predict/page.tsx
+++ b/apps/web/app/predict/page.tsx
@@ -128,9 +128,7 @@ export default function PredictPage() {
 									</div>
 									<div className="flex justify-between">
 										<span className="text-foreground-muted">Confidence</span>
-										<span className="font-medium">
-											{(prediction.confidence * 100).toFixed(2)}%
-										</span>
+										<span className="font-medium">{(prediction.confidence * 100).toFixed(2)}%</span>
 									</div>
 									<div className="flex justify-between">
 										<span className="text-foreground-muted">Threshold</span>

--- a/apps/web/app/predict/page.tsx
+++ b/apps/web/app/predict/page.tsx
@@ -50,12 +50,14 @@ export default function PredictPage() {
 	return (
 		<div className="space-y-8">
 			<div>
-				<h1 className="text-2xl font-bold text-gray-900">Predict Default</h1>
-				<p className="mt-1 text-gray-600">Submit a loan application to predict default risk.</p>
+				<h1 className="text-2xl font-bold text-foreground">Predict Default</h1>
+				<p className="mt-1 text-foreground-secondary">
+					Submit a loan application to predict default risk.
+				</p>
 			</div>
 
 			{error && (
-				<div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+				<div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 p-4 text-sm text-red-800 dark:text-red-200">
 					{error}
 				</div>
 			)}
@@ -64,7 +66,7 @@ export default function PredictPage() {
 				<div className="lg:col-span-2">
 					<Card title="Loan Application">
 						{modelsLoading ? (
-							<p className="text-sm text-gray-500">Loading models...</p>
+							<p className="text-sm text-foreground-muted">Loading models...</p>
 						) : (
 							<PredictionForm models={models} onSubmit={handlePredict} loading={loading} />
 						)}
@@ -76,7 +78,7 @@ export default function PredictPage() {
 						<Card>
 							<div className="flex items-center justify-center py-8">
 								<svg
-									className="h-6 w-6 animate-spin text-blue-600"
+									className="h-6 w-6 animate-spin text-primary"
 									viewBox="0 0 24 24"
 									fill="none"
 									role="img"
@@ -107,8 +109,8 @@ export default function PredictPage() {
 									<div
 										className={`inline-block rounded-full px-6 py-3 text-lg font-bold ${
 											prediction.predicted_default
-												? "bg-red-100 text-red-800"
-												: "bg-green-100 text-green-800"
+												? "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200"
+												: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200"
 										}`}
 									>
 										{prediction.predicted_default ? "Default" : "No Default"}
@@ -119,21 +121,23 @@ export default function PredictPage() {
 							<Card title="Details">
 								<div className="space-y-3 text-sm">
 									<div className="flex justify-between">
-										<span className="text-gray-500">Default Probability</span>
+										<span className="text-foreground-muted">Default Probability</span>
 										<span className="font-medium">
 											{(prediction.default_probability * 100).toFixed(2)}%
 										</span>
 									</div>
 									<div className="flex justify-between">
-										<span className="text-gray-500">Confidence</span>
-										<span className="font-medium">{(prediction.confidence * 100).toFixed(2)}%</span>
+										<span className="text-foreground-muted">Confidence</span>
+										<span className="font-medium">
+											{(prediction.confidence * 100).toFixed(2)}%
+										</span>
 									</div>
 									<div className="flex justify-between">
-										<span className="text-gray-500">Threshold</span>
+										<span className="text-foreground-muted">Threshold</span>
 										<span className="font-medium">{result.threshold.toFixed(4)}</span>
 									</div>
 									<div className="flex justify-between">
-										<span className="text-gray-500">Model</span>
+										<span className="text-foreground-muted">Model</span>
 										<span className="font-medium">{result.model_type}</span>
 									</div>
 								</div>
@@ -141,12 +145,12 @@ export default function PredictPage() {
 
 							<Card title="Probability Bar">
 								<div className="space-y-2">
-									<div className="flex justify-between text-xs text-gray-500">
+									<div className="flex justify-between text-xs text-foreground-muted">
 										<span>0%</span>
 										<span>Threshold ({(result.threshold * 100).toFixed(0)}%)</span>
 										<span>100%</span>
 									</div>
-									<div className="relative h-4 w-full overflow-hidden rounded-full bg-gray-200">
+									<div className="relative h-4 w-full overflow-hidden rounded-full bg-surface-elevated">
 										<div
 											className={`absolute left-0 top-0 h-full rounded-full transition-all ${
 												prediction.predicted_default ? "bg-red-500" : "bg-green-500"
@@ -156,7 +160,7 @@ export default function PredictPage() {
 											}}
 										/>
 										<div
-											className="absolute top-0 h-full w-0.5 bg-gray-800"
+											className="absolute top-0 h-full w-0.5 bg-foreground"
 											style={{ left: `${result.threshold * 100}%` }}
 										/>
 									</div>
@@ -167,7 +171,7 @@ export default function PredictPage() {
 
 					{!loading && !prediction && (
 						<Card>
-							<p className="text-center text-sm text-gray-500">
+							<p className="text-center text-sm text-foreground-muted">
 								Fill in the loan application form and click &quot;Get Prediction&quot; to see
 								results.
 							</p>

--- a/apps/web/components/forms/prediction-form.tsx
+++ b/apps/web/components/forms/prediction-form.tsx
@@ -64,7 +64,7 @@ export function PredictionForm({ models, onSubmit, loading = false }: Prediction
 
 	if (models.length === 0) {
 		return (
-			<div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">
+			<div className="rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-950 p-4 text-sm text-yellow-800 dark:text-yellow-200">
 				No trained models available. Train a model first.
 			</div>
 		);

--- a/apps/web/components/forms/training-form.tsx
+++ b/apps/web/components/forms/training-form.tsx
@@ -66,11 +66,11 @@ export function TrainingForm({ onSubmit, loading = false }: TrainingFormProps) {
 				<input
 					id="undersample"
 					type="checkbox"
-					className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+					className="h-4 w-4 rounded border-border-strong text-primary focus:ring-focus-ring"
 					checked={config.undersample}
 					onChange={(e) => setConfig({ ...config, undersample: e.target.checked })}
 				/>
-				<label htmlFor="undersample" className="text-sm font-medium text-gray-700">
+				<label htmlFor="undersample" className="text-sm font-medium text-foreground-secondary">
 					Undersample majority class
 				</label>
 			</div>


### PR DESCRIPTION
## Summary

- Bump dark mode CSS variables to meet WCAG Level AAA contrast requirements (7:1 normal text, 4.5:1 large text, 3:1 non-text UI per SC 1.4.11)
- Replace all hardcoded Tailwind `gray-*` classes with semantic tokens (`text-foreground`, `text-foreground-secondary`, `text-foreground-muted`, `border-border`, etc.)
- Add `dark:` variants to error/warning alert boxes and prediction outcome badges
- Switch button foreground to dark text on bright backgrounds in dark mode for AAA compliance

### Key contrast ratios (dark mode, on `#0a0a0a` background)
| Token | Color | Ratio |
|-------|-------|-------|
| foreground | #fafafa | 19.0:1 |
| foreground-secondary | #d4d4d4 | 13.4:1 |
| foreground-muted | #c0c0c0 | 10.1:1 |
| primary | #60a5fa | 7.8:1 |
| danger | #f87171 | 7.2:1 |
| success | #10b981 | 7.8:1 |
| border | #666666 | 3.5:1 |

### Files changed
- `globals.css` — dark mode CSS variable values
- `app/page.tsx`, `app/predict/page.tsx`, `app/compare/page.tsx` — semantic tokens
- `components/forms/training-form.tsx`, `components/forms/prediction-form.tsx` — semantic tokens + dark variants

## Test plan
- [ ] Toggle dark mode on each page (/, /train, /predict, /compare)
- [ ] Verify all text is clearly readable with high contrast
- [ ] Verify error/warning alerts display correctly in both modes
- [ ] Verify buttons have readable text in both modes
- [ ] Spot-check contrast ratios with browser DevTools accessibility panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)