### PR TITLE
docs: backfill changelog, add skills, streamline CLAUDE.md

### DIFF
--- a/.claude_skills/adr/SKILL.md
+++ b/.claude_skills/adr/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: adr
+description: Create Architecture Decision Records (ADRs). Use when the user wants to record an architectural decision, document a technical choice, or when creating a new ADR for a PR.
+---
+
+# ADR Skill
+
+Create well-structured Architecture Decision Records for the Credit Risk Platform.
+
+## When to Write an ADR
+
+**ADR warranted when:**
+
+- Choosing between technologies, libraries, or patterns
+- Making a decision that constrains future options
+- Removing or replacing existing functionality
+- Choosing a deployment strategy or infrastructure pattern
+- Any decision someone might later ask "why did we do it this way?"
+
+**ADR NOT warranted when:**
+
+- The choice is obvious and uncontroversial (e.g., using pytest for Python tests)
+- It's a temporary decision that will be revisited soon
+- The decision is purely cosmetic (formatting, naming that follows existing conventions)
+
+## Creation Steps
+
+### 1. Pick the next number
+
+```bash
+# Check the highest ADR number on main (not your branch)
+ls docs/1-ADRs/ADR-*.md | sort -V | tail -1
+```
+
+**Conflict avoidance** (when working in parallel):
+
+- Check open PRs for new ADR files: `gh pr list --search "ADR" --state open`
+- If a conflict is found at merge time, renumber the later PR's ADR
+- Never reuse a number that appeared in a merged PR, even if the file was later deleted
+
+### 2. Create the file
+
+File: `docs/1-ADRs/ADR-NNN-short-description.md`
+
+Use the template in `references/adr-template.md`.
+
+Required metadata table:
+
+```markdown
+# ADR-NNN: Title
+
+| Field | Value |
+|-------|-------|
+| Status | Proposed |
+| Author | Paul / Claude |
+| Date | YYYY-MM-DD |
+| PR | _Added before merge_ |
+```
+
+Status lifecycle: `Proposed` -> `Accepted` -> `Superseded` (or `Rejected`)
+
+### 3. Write the content
+
+Focus on:
+
+- **Context**: What situation or problem prompted this decision?
+- **Decision**: What did we decide? Be specific.
+- **Consequences**: What are the trade-offs? What becomes easier/harder?
+- **Alternatives**: What else was considered and why was it rejected?
+
+### 4. Before merging the PR
+
+- [ ] Add the `| PR |` link to the ADR metadata table
+- [ ] Add the new ADR to `docs/1-ADRs/ADR-README.md` index table
+- [ ] Verify no numbering conflict with other open/recently-merged PRs
+
+## ADR Quality Guidelines
+
+**Good ADRs:**
+
+- Explain the "why" — future readers need context, not just the conclusion
+- Are honest about trade-offs — every decision has downsides
+- Are concise — 1-2 pages is ideal; if longer, the decision may need splitting
+- Stand alone — a reader shouldn't need to read other docs to understand this one
+
+**Bad ADRs:**
+
+- Just state the decision with no context or alternatives
+- Read like a tutorial or how-to guide (that belongs in docs/)
+- Are so long they'll never be read
+
+## Example
+
+**Good context section:**
+> We need to choose a chart library for the Next.js production UI. The app displays ROC curves, calibration plots, and confusion matrices. We need responsive, accessible charts that work with React 19 and support dark mode.
+
+**Weak context section:**
+> We need charts.
+
+See `references/adr-template.md` for the full template.

--- a/.claude_skills/adr/references/adr-template.md
+++ b/.claude_skills/adr/references/adr-template.md
@@ -1,0 +1,50 @@
+# ADR Template
+
+Copy and fill in this template for new ADRs.
+
+---
+
+# ADR-NNN: Title
+
+| Field | Value |
+|-------|-------|
+| Status | Proposed |
+| Author | Paul / Claude |
+| Date | YYYY-MM-DD |
+| PR | _Added before merge_ |
+
+## Context
+
+[What situation or problem prompted this decision? Include relevant constraints, requirements, and background.]
+
+## Decision
+
+[What did we decide? Be specific about what will be done.]
+
+## Consequences
+
+### Positive
+
+- [What becomes easier or better]
+
+### Negative
+
+- [What becomes harder or is a trade-off]
+
+### Neutral
+
+- [Side effects that are neither clearly positive nor negative]
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+[Brief description]
+
+**Why not chosen:** [Reasoning]
+
+### Alternative 2: [Name]
+
+[Brief description]
+
+**Why not chosen:** [Reasoning]

--- a/.claude_skills/changelog/SKILL.md
+++ b/.claude_skills/changelog/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: changelog
+description: Maintain and update the project CHANGELOG.md. Use when merging PRs, preparing releases, when the user asks to update the changelog, add changelog entries, or review changelog quality.
+---
+
+# Changelog Skill
+
+Maintain `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with project-specific conventions.
+
+## When to Update the Changelog
+
+**Add an entry for every PR that:**
+
+- Adds, changes, or removes user-facing behavior
+- Fixes a bug
+- Changes dependencies that affect runtime behavior
+- Modifies the API surface (endpoints, schemas, request/response shapes)
+- Changes deployment configuration that affects how the app runs
+
+**Do NOT add entries for:**
+
+- Documentation-only PRs (README, ADR, RFC updates)
+- CI-only changes (workflow tweaks, linting config)
+- Internal refactors that do not change observable behavior
+- Test-only changes
+
+**Gray areas:** If a CI change enables a new deployment target (e.g., adding a Dockerfile for Cloud Run), that IS changelog-worthy under Infrastructure. Use judgment — if a user or operator would care, include it.
+
+## Entry Format
+
+```
+- [scope] Brief imperative description (#PR)
+```
+
+### Rules
+
+1. **Scope** matches the conventional commit scopes used in this project: `shared`, `api`, `web`, `gradio`, `marimo`, `ci`, `chore`
+2. **Description** uses imperative mood, present tense: "Add dark mode toggle" not "Added dark mode toggle"
+3. **PR number** at the end in parentheses. Multiple PRs OK: `(#38, #39)`
+4. **One entry per PR** unless the PR genuinely does multiple independent things
+5. **Focus on what changed for the user**, not implementation details
+
+### Examples
+
+**Good:**
+
+```
+- [web] Add dark mode toggle with system preference detection (#46)
+- [api] Fix rate limiter bypassing on preflight requests (#39)
+- [shared] Add automatic feature selection: Boruta, Lasso, Tree Importance, WOE-IV (#38)
+```
+
+**Bad:**
+
+```
+- Added dark mode                              # No scope, no PR, vague
+- feat(web): add dark mode toggle (#46)        # Commit message format, not changelog
+- [web] Refactored CSS class naming (#46)      # Internal detail, not user-facing
+- Fixed bug                                    # Useless
+```
+
+## Section Placement
+
+Place entries in `[Unreleased]` under the correct Keep a Changelog category:
+
+| Section | Use for |
+|---------|---------|
+| **Added** | New features, endpoints, pages, deployment targets |
+| **Changed** | Changes to existing functionality, dependency upgrades, behavior changes |
+| **Deprecated** | Features marked for future removal |
+| **Removed** | Features that were removed |
+| **Fixed** | Bug fixes |
+| **Security** | Vulnerability fixes, security improvements |
+
+### Sub-grouping (initial releases only)
+
+For large initial releases (like 0.1.0), the Added section may use sub-headings by layer:
+
+```markdown
+### Added
+
+#### Shared Layer (`shared/`)
+- [shared] ...
+
+#### API Layer (`apps/api/`)
+- [api] ...
+```
+
+Do NOT use sub-headings for ongoing releases — they add noise when there are only a few entries per section.
+
+## Release Workflow
+
+When cutting a release:
+
+1. Move all `[Unreleased]` entries to a new versioned section `[X.Y.Z] - YYYY-MM-DD`
+2. Add a fresh empty `[Unreleased]` section above
+3. Verify the version matches `pyproject.toml` and `apps/web/package.json`
+4. Add comparison links at the bottom of the file (if using GitHub releases)
+
+## Backfill Guidance
+
+When catching up on missed entries:
+
+```bash
+# List all merged PRs not yet in the changelog
+gh pr list --state merged --json number,title,mergedAt --limit 100
+```
+
+Cross-reference with existing CHANGELOG.md entries. For each missing PR, evaluate whether it meets the "when to update" criteria above.
+
+## Quality Checklist
+
+Run through this before finalizing changelog updates:
+
+- [ ] Every entry has a `[scope]` prefix
+- [ ] Every entry has a PR number reference `(#NN)`
+- [ ] Entries use imperative mood
+- [ ] No duplicate entries across sections
+- [ ] Entries are under the correct category (Added/Changed/Fixed/etc.)
+- [ ] `[Unreleased]` section exists at the top
+- [ ] No entry appears in both Unreleased and a versioned section
+- [ ] Removed entries are in Changed (if replaced) or Removed (if deleted)
+
+See `references/changelog-template.md` for the standard file structure.

--- a/.claude_skills/changelog/references/changelog-template.md
+++ b/.claude_skills/changelog/references/changelog-template.md
@@ -1,0 +1,28 @@
+# Changelog Template
+
+Use this structure when creating or resetting `CHANGELOG.md`.
+
+---
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- [scope] Description (#PR)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/.claude_skills/git-workflow/SKILL.md
+++ b/.claude_skills/git-workflow/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: git-workflow
+description: Reference guide for advanced git workflow patterns including worktrees, parallel development, and periodic cleanup. Use when setting up worktrees, doing parallel development, or cleaning up stale branches.
+---
+
+# Git Workflow Skill
+
+Advanced git workflow patterns for the Credit Risk Platform monorepo. For basic branch naming, commit conventions, and the standard workflow, see CLAUDE.md.
+
+## Periodic Cleanup
+
+Run periodically (or at the start of a session) to catch accumulated stale branches and worktrees:
+
+```bash
+# 1. Check for stale worktrees
+git worktree list                    # Should only show main worktree if no parallel work active
+
+# 2. Remove any worktrees for merged PRs
+git worktree remove ../credit-risk-[name]
+
+# 3. Delete local branches whose PRs are merged
+git branch                           # Review list
+git branch -d [branch-name]          # -d is safe (refuses if unmerged)
+
+# 4. Prune stale remote tracking refs
+git remote prune origin
+```
+
+> **Tip:** If many branches have accumulated, check PR status with `gh pr list --state merged --json headRefName`.
+
+## Parallel Development: Branches vs Worktrees
+
+**Default**: Use branches. Only add worktrees when you need two working directories simultaneously.
+
+### When to Use What
+
+| Scenario | Use | Why |
+|----------|-----|-----|
+| Sequential feature work | Branch only | One task at a time, no extra setup |
+| Quick fix while on a feature branch | Branch only | Stash, switch, fix, switch back |
+| Working on `apps/api/` while testing `shared/` changes | Worktree | Need both running simultaneously |
+| `apps/web/` + `apps/api/` dev in parallel | Worktree | Separate `node_modules` and `.venv` needed |
+| Reviewing a PR while mid-feature | Worktree | Avoid stashing incomplete work |
+| Long-running `docs/` + `feature/` tasks | Worktree | Independent streams, no context switching |
+
+### Monorepo-Specific Notes
+
+- **`shared/` changes cascade** to all apps — a worktree lets you test against apps without stash/switch cycles
+- **Independent apps** (`apps/web/`, `apps/api/`, `apps/gradio/`) rarely conflict — parallel worktrees work well
+- **`docs/`** is always safe for parallel worktrees since it never conflicts with code
+
+## Worktree Commands
+
+```bash
+# Add a worktree for a new branch (from main)
+git worktree add -b feature/api-auth ../credit-risk-api main
+
+# Add a worktree for an existing branch
+git worktree add ../credit-risk-docs docs/update-readme
+
+# List all worktrees
+git worktree list
+
+# Remove a worktree (after merging/done)
+git worktree remove ../credit-risk-docs
+```
+
+**Naming convention** for worktree directories: `../credit-risk-[purpose]`
+
+```text
+Dev/Repos/
+├── tool-credit-risk-modelling/      <- main worktree (primary)
+├── credit-risk-docs/                <- docs worktree
+├── credit-risk-api/                 <- api feature worktree
+└── credit-risk-web/                 <- web feature worktree
+```
+
+## Worktree Gotchas
+
+| Gotcha | Detail |
+|--------|--------|
+| Same branch in two worktrees | **Not allowed.** Git prevents checking out the same branch in multiple worktrees. |
+| Shared `.git` | All worktrees share one `.git` directory. Commits in any worktree are visible to all. |
+| `node_modules` / `.venv` per worktree | Each worktree needs its own install. Run `npm install` and `uv sync` in each new worktree. |
+| `.env` files | Not tracked by git. Copy `.env` manually to each new worktree. |
+| Branch naming still applies | Worktree branches follow the same `feature/`, `fix/`, `docs/` convention. |
+| Cleanup | Always use `git worktree remove`, not `rm -rf`. Stale entries break `git worktree list`. |
+
+## Worktree + Branch Workflow
+
+```bash
+# 1. You're mid-feature on a branch. Need to start parallel work.
+
+# 2. Create a worktree for the new task (branches from main)
+git worktree add -b feature/new-task ../credit-risk-new-task main
+
+# 3. Set up the new worktree
+cd ../credit-risk-new-task
+uv sync                         # Python deps
+cd apps/web && npm install      # Node deps (if needed)
+
+# 4. Work, commit, push, PR from the worktree
+git push -u origin feature/new-task
+gh pr create --title "feat(scope): description"
+
+# 5. Clean up after merge
+cd ../tool-credit-risk-modelling
+git worktree remove ../credit-risk-new-task
+```

--- a/.claude_skills/rfc/SKILL.md
+++ b/.claude_skills/rfc/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: rfc
+description: Create, review, and edit Request for Comments (RFC) documents for technical proposals. Use when the user wants to write an RFC, design document, technical proposal, or feature specification. Also use when reviewing or providing feedback on existing RFCs, or when converting ideas into structured technical proposals.
+---
+
+# RFC Skill
+
+Create well-structured RFC (Request for Comments) documents for technical proposals.
+
+## When to Write an RFC
+
+Not all code needs a design doc. Before drafting, assess whether an RFC is warranted.
+
+**RFC likely warranted when:**
+
+- The design is ambiguous or contentious and organizational consensus would be valuable
+- Cross-cutting concerns exist (privacy, security, logging, observability)
+- The project has non-obvious trade-offs worth documenting
+- There's value in providing high-level insights into legacy systems
+- Multiple engineers need to coordinate on implementation
+
+**RFC likely NOT warranted when:**
+
+- The solution is obvious and uncontroversial
+- It's a small bug fix or minor refactor
+- The change is well-understood and low-risk
+- No coordination across teams is needed
+
+**Skill behavior:** If the user's request suggests a straightforward change where an RFC may be overkill, ask whether they still want a formal RFC or if a lighter-weight approach (e.g., PR description, brief design notes) would suffice.
+
+## RFC Structure
+
+Every RFC should include these sections. Adapt depth based on proposal complexity.
+
+### Required Sections
+
+**1. Header Metadata**
+Include at minimum: Title, Status, Author(s), Date. Optional: Sponsor, GitHub/Issue link, Supersedes/Obsoletes.
+
+Status options: Draft → Proposed → Accepted → Implemented → Obsolete
+
+**2. Objective**
+Executive summary: what you're proposing and why. Keep to 2-3 sentences.
+
+Include explicit **goals** and **non-goals**. Non-goals are not negated goals ("system shouldn't crash") but things that *could reasonably be goals* but are explicitly chosen not to be. This clarifies scope and prevents scope creep.
+
+**3. Motivation**
+
+- Why is this problem worth solving?
+- Who is affected and how?
+- What existing solutions fall short?
+- Supporting data or evidence
+
+**4. User Benefit**
+How will users benefit? What would the release notes say? Keep concrete and user-focused.
+
+**5. Design Proposal**
+The core of the RFC. This is *the place to write down the trade-offs* you made in designing your solution. Don't just describe what—explain *why* this solution best satisfies the goals given the context.
+
+Include:
+
+- **System-context diagram** — Show how the new system fits into the larger technical landscape. Use Mermaid.js for diagrams (renders in GitHub, Notion, most doc platforms). Helps readers contextualize the design within systems they already know.
+- **High-level approach** — Start with overview, then go into details.
+- **Key design decisions and trade-offs** — Focus on *why*, not just *what*.
+- **APIs** — If exposing an API, sketch it out. But resist copy-pasting verbose interface definitions; focus on parts relevant to design trade-offs.
+- **Data storage** — How and where data is stored, if applicable.
+- **Usage examples** — Concrete examples of how the feature will be used.
+
+**6. Alternatives Considered**
+What other approaches were evaluated? Why was this approach chosen? Be honest about tradeoffs.
+
+### Conditional Sections
+
+Include these when relevant to your proposal:
+
+**Dependencies** - New dependencies introduced; projects that depend on this
+
+**Engineering Impact** - Maintenance ownership, testability, build impact, API surface
+
+**Platforms and Environments** - Compatibility with different platforms, devices, or execution environments
+
+**Best Practices** - Changes to recommended practices; how to communicate them
+
+**Tutorials and Examples** - Plans for documentation, tutorials, sample code
+
+**User Impact** - User-facing changes, migration requirements
+
+**Deprecation Plan** - How existing functionality will be phased out
+
+**Detailed Design** - Technical deep-dive for complex proposals (can be separate document)
+
+**Questions and Discussion Topics** - Open questions for reviewers to address
+
+## Writing Guidelines
+
+1. **Focus on trade-offs** — The design doc exists to document *why* you chose this solution. Given the context (facts), goals, and non-goals (requirements), show why this particular solution best satisfies those goals.
+
+2. **Be specific** — Avoid vague language. Use concrete examples.
+
+3. **Know your audience** — Write for both technical reviewers and stakeholders who need context.
+
+4. **Front-load key information** — Objective and Motivation should stand alone as a summary.
+
+5. **Use diagrams** — System-context diagrams help readers understand how the new design fits into the existing landscape.
+
+6. **Don't over-document APIs** — Sketch relevant interfaces, but avoid verbose copy-paste of formal definitions that quickly go out of date.
+
+7. **Acknowledge tradeoffs** — Honest discussion of alternatives builds trust.
+
+8. **Keep it living** — Update status and content as the RFC progresses.
+
+## Output Format
+
+Create RFCs as Markdown (.md) files by default. For formal documents, create as Word (.docx) using the docx skill.
+
+See `references/rfc-template.md` for a ready-to-use template.
+
+## Example Objective Section
+
+**Good:**
+> Add a caching layer for database queries to reduce latency by 50% for repeated requests. Goals: sub-10ms response for cached queries, minimal memory overhead (<100MB). Non-goals: distributed caching (out of scope for v1), cache invalidation across services (handled by existing pub/sub).
+
+**Weak:**
+> Make the system faster by adding caching.
+
+**Non-goals done right:**
+Non-goals are things that *could* be goals but are explicitly scoped out. "The system shouldn't crash" is not a non-goal—that's just a requirement. "Supporting real-time sync" when you're building batch processing is a proper non-goal.

--- a/.claude_skills/rfc/references/rfc-template.md
+++ b/.claude_skills/rfc/references/rfc-template.md
@@ -1,0 +1,163 @@
+# RFC Template
+
+Copy and fill in this template for new RFCs.
+
+---
+
+# [Title of RFC]
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Author(s) | Name (email) |
+| Updated | YYYY-MM-DD |
+| GitHub Issue | (link, if applicable) |
+| Sponsor | (optional) |
+| Obsoletes | (RFC it replaces, if any) |
+
+## Objective
+
+[2-3 sentence summary of what you're proposing and why.]
+
+**Goals:**
+
+- [Concrete, measurable goal]
+- [Another goal]
+
+**Non-goals:** (things that could reasonably be goals but are explicitly out of scope)
+
+- [Explicit non-goal and brief rationale]
+
+## Motivation
+
+[Why is this problem worth solving? Include:]
+
+- Background context
+- Who is affected
+- Current limitations or pain points
+- Supporting data or evidence
+
+## User Benefit
+
+[How will users benefit? What would the headline be in release notes?]
+
+## Design Proposal
+
+### System Context
+
+[Diagram showing how this system fits into the larger technical landscape.]
+
+```mermaid
+flowchart TB
+    subgraph Clients
+        A[Frontend A]
+        B[Frontend B]
+    end
+    
+    A --> NS[New System<br/>this RFC]
+    B --> NS
+    
+    NS --> DB[(Database)]
+    NS --> SY[Service Y]
+    NS --> SZ[Service Z]
+```
+
+[Adapt the diagram to show your actual system boundaries and dependencies.]
+
+### Overview
+
+[High-level description of the approach]
+
+### Key Design Decisions
+
+[Focus on trade-offs: given the context and goals, why does this solution best satisfy them?]
+
+### API / Interface Changes
+
+[If applicable, sketch the new or modified interfaces. Focus on design-relevant parts, not verbose definitions.]
+
+```
+// Example code or pseudocode
+```
+
+### Data Storage
+
+[If applicable, how and where data is stored]
+
+### Usage Examples
+
+[Show how the feature would be used in practice]
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+[Description]
+
+**Pros:** [advantages]
+
+**Cons:** [disadvantages]
+
+**Why not chosen:** [reasoning]
+
+### Alternative 2: [Name]
+
+[Description]
+
+**Pros:** [advantages]
+
+**Cons:** [disadvantages]
+
+**Why not chosen:** [reasoning]
+
+## Dependencies
+
+- **New dependencies:** [List any new libraries, services, or external dependencies]
+- **Dependent projects:** [Projects that rely on or are affected by this change]
+
+## Engineering Impact
+
+- **Maintenance:** [Who will own and maintain this code?]
+- **Testing:** [How will this be tested? What coverage is expected?]
+- **Build impact:** [Any changes to build process or artifacts?]
+- **API surface:** [Changes to public API surface area]
+
+## Platforms and Environments
+
+- **Platform compatibility:** [Does this work across all supported platforms?]
+- **Execution environments:** [Simulators, production, specific hardware, etc.]
+
+## Best Practices
+
+[Does this change recommended practices? How will changes be communicated?]
+
+## Tutorials and Examples
+
+[Plans for documentation, tutorials, or example code]
+
+## User Impact
+
+- **User-facing changes:** [What changes will users see?]
+- **Migration:** [Any migration steps required?]
+
+## Deprecation Plan
+
+[If replacing existing functionality, how will the old code be deprecated?]
+
+## Detailed Design
+
+[Optional: Technical deep-dive for complex proposals. Can reference separate documents.]
+
+## Questions and Discussion Topics
+
+1. [Open question for reviewers]
+2. [Another open question]
+3. [Areas where feedback is especially needed]
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| YYYY-MM-DD | Name | Initial draft |

--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,4 @@ apps/gradio/flagged/
 # ----------------------------------------
 .claudeignore
 .claude/
-.claude_skills/
-claude_skills/
-skills/
 .prompts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,105 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
+## [0.1.0] - 2026-02-11
+
+Initial release — migrated from a Streamlit prototype to a production-grade monorepo
+with four integrated application layers.
+
 ### Added
-- Credit risk model training API (FastAPI, async)
-- Shared Pydantic schemas and business logic layer
-- Interactive Marimo notebooks for exploration
-- Gradio stakeholder demo app
-- Next.js production UI with TypeScript strict mode
-- API key authentication
-- Model persistence (in-memory + filesystem)
-- Rate limiting on API endpoints
-- Audit logging for training and prediction events
+
+#### Shared Layer (`shared/`)
+
+- [shared] Pydantic v2 schemas for loan applications, training results, predictions, and audit logs (#12)
+- [shared] Preprocessing and evaluation logic using sklearn (#12)
+- [shared] Threshold optimization using Youden's J statistic (#12)
+- [shared] Automatic feature selection: Boruta, Lasso, Tree Importance, WOE-IV (#38)
+
+#### API Layer (`apps/api/`)
+
+- [api] FastAPI service with health, train, predict, and model endpoints (#12)
+- [api] API key authentication with configurable enforcement (#19)
+- [api] Rate limiting and audit logging (#19)
+- [api] Model persistence with in-memory cache and filesystem storage (#12)
+- [api] Feature selection endpoint supporting four methods (#38)
+
+#### Gradio App (`apps/gradio/`)
+
+- [gradio] Training tab with model configuration and feature selection (#12, #31)
+- [gradio] Prediction tab with probability display (#12)
+- [gradio] Model comparison tab (#12)
+- [gradio] Deployed to Hugging Face Spaces (#26)
+
+#### Next.js UI (`apps/web/`)
+
+- [web] Next.js 16 scaffold with App Router, TypeScript strict, and Recharts dashboard (#17)
+- [web] Training page with ROC curve, calibration plot, and confusion matrix (#17)
+- [web] Prediction page with input form and probability visualizations (#17)
+- [web] Model comparison page with side-by-side metrics (#17)
+- [web] Dark mode toggle with system preference detection (#46)
+- [web] Deployed to Cloud Run (#37)
+
+#### Notebooks (`notebooks/`)
+
+- [marimo] Interactive exploration notebooks stored as `.py` files (#14)
+- [marimo] Deployed to Hugging Face Spaces via Docker (#36)
+- [marimo] Landing page with HF Spaces link (#41)
+
+#### Infrastructure
+
+- [ci] Monorepo setup with uv, Ruff, pyproject.toml (#12)
+- [ci] Pytest + npm test coverage reporting (#24)
+- [ci] deptry dependency checking and security scanning (#24, #25)
+- [ci] Dockerfile and Cloud Run deployment workflow for API (#30)
+- [ci] Monorepo-aware Gradio deploy to HF Spaces (#26, #28)
+- [ci] Cloud Run deployment for Next.js app (#37)
+
+#### Documentation
+
+- [docs] RFC-001: Platform Architecture
+- [docs] RFC-002: API Layer
+- [docs] RFC-006: Auth & Security
+- [docs] ADR-001 through ADR-014 covering all architectural decisions (#40)
+- [docs] Deployment guide for Cloud Run and HF Spaces (#43)
+- [docs] Environment variables reference
+- [docs] Parallel development and worktree guidance (#35)
+
+### Changed
+
+- [gradio] Upgraded Gradio from 4.0.0 to 6.5.1 (#29)
+- [marimo] Added tabulate dependency for pandas `to_markdown` (#42)
+- [web] Removed authentication layer — internal tool, unnecessary friction (#44)
+- [gradio] Removed authentication layer (#45)
+
+### Fixed
+
+- [shared/api] Phase 1-2 code review fixes (#13)
+- [notebooks] Phase 3 review fixes (#15)
+- [gradio] Phase 4 review fixes — session state, error handling, loading states (#16)
+- [web] Phase 5 review fixes — validation, compare toggle, RFC decisions (#18)
+- [api] Security hardening from Phase 6 review (#20)
+- [ci] deptry monorepo configuration (#25)
+- [ci] HF Spaces deploy git init and python_version (#27, #28)
+- [ci] Copy shared/constants.py to HF Spaces deployment (#32)
+- [gradio] Compare tab not showing trained models (#33)
+- [gradio] Boruta feature selection timeout (#39)
+- [web] Trailing slashes on API endpoint paths (#47)
+- [web] Dark mode WCAG AAA color contrast (#48)
 
 ### Security
-- CORS configuration
-- Security headers in Next.js
-- SameSite/Secure cookie flags
-- Input validation via Pydantic schemas
-- Path traversal protection in model store
 
-### Documentation
-- RFC-001: Platform Architecture
-- RFC-002: API Layer
-- RFC-006: Auth & Security
-- ADR-001 through ADR-008 covering all architectural decisions
-- Environment variables reference
-- Deployment guide
+- [api] CORS configuration with configurable origins
+- [web] Security headers in Next.js (CSP, X-Frame-Options, etc.)
+- [api] Input validation via Pydantic schemas
+- [api] Path traversal protection in model store
+- [api] Security hardening audit (#20)
+
+### Pre-monorepo
+
+- Initial Streamlit prototype with credit risk model (#1, #7, #11)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,106 +135,9 @@ git reflog  # Find the commit hash
 git checkout -b recovery-branch [commit-hash]
 ```
 
-### Periodic Cleanup
+### Parallel Development and Worktrees
 
-Run periodically (or at the start of a session) to catch accumulated stale branches and worktrees:
-
-```bash
-# 1. Check for stale worktrees
-git worktree list                    # Should only show main worktree if no parallel work active
-
-# 2. Remove any worktrees for merged PRs
-git worktree remove ../credit-risk-[name]
-
-# 3. Delete local branches whose PRs are merged
-git branch                           # Review list
-git branch -d [branch-name]          # -d is safe (refuses if unmerged)
-
-# 4. Prune stale remote tracking refs
-git remote prune origin
-```
-
-> **Tip:** If many branches have accumulated, check PR status with `gh pr list --state merged --json headRefName`.
-
-### Parallel Development: Branches vs Worktrees
-
-**Default**: Use branches. Only add worktrees when you need two working directories simultaneously.
-
-#### When to Use What
-
-| Scenario | Use | Why |
-|----------|-----|-----|
-| Sequential feature work | Branch only | One task at a time, no extra setup |
-| Quick fix while on a feature branch | Branch only | Stash, switch, fix, switch back |
-| Working on `apps/api/` while testing `shared/` changes | Worktree | Need both running simultaneously |
-| `apps/web/` + `apps/api/` dev in parallel | Worktree | Separate `node_modules` and `.venv` needed |
-| Reviewing a PR while mid-feature | Worktree | Avoid stashing incomplete work |
-| Long-running `docs/` + `feature/` tasks | Worktree | Independent streams, no context switching |
-
-#### Monorepo-Specific Notes
-
-- **`shared/` changes cascade** to all apps — a worktree lets you test against apps without stash/switch cycles
-- **Independent apps** (`apps/web/`, `apps/api/`, `apps/gradio/`) rarely conflict — parallel worktrees work well
-- **`docs/`** is always safe for parallel worktrees since it never conflicts with code
-
-#### Worktree Commands
-
-```bash
-# Add a worktree for a new branch (from main)
-git worktree add -b feature/api-auth ../credit-risk-api main
-
-# Add a worktree for an existing branch
-git worktree add ../credit-risk-docs docs/update-readme
-
-# List all worktrees
-git worktree list
-
-# Remove a worktree (after merging/done)
-git worktree remove ../credit-risk-docs
-```
-
-**Naming convention** for worktree directories: `../credit-risk-[purpose]`
-
-```text
-Dev/Repos/
-├── tool-credit-risk-modelling/      ← main worktree (primary)
-├── credit-risk-docs/                ← docs worktree
-├── credit-risk-api/                 ← api feature worktree
-└── credit-risk-web/                 ← web feature worktree
-```
-
-#### Worktree Gotchas
-
-| Gotcha | Detail |
-|--------|--------|
-| Same branch in two worktrees | **Not allowed.** Git prevents checking out the same branch in multiple worktrees. |
-| Shared `.git` | All worktrees share one `.git` directory. Commits in any worktree are visible to all. |
-| `node_modules` / `.venv` per worktree | Each worktree needs its own install. Run `npm install` and `uv sync` in each new worktree. |
-| `.env` files | Not tracked by git. Copy `.env` manually to each new worktree. |
-| Branch naming still applies | Worktree branches follow the same `feature/`, `fix/`, `docs/` convention. |
-| Cleanup | Always use `git worktree remove`, not `rm -rf`. Stale entries break `git worktree list`. |
-
-#### Worktree + Branch Workflow
-
-```bash
-# 1. You're mid-feature on a branch. Need to start parallel work.
-
-# 2. Create a worktree for the new task (branches from main)
-git worktree add -b feature/new-task ../credit-risk-new-task main
-
-# 3. Set up the new worktree
-cd ../credit-risk-new-task
-uv sync                         # Python deps
-cd apps/web && npm install      # Node deps (if needed)
-
-# 4. Work, commit, push, PR from the worktree
-git push -u origin feature/new-task
-gh pr create --title "feat(scope): description"
-
-# 5. Clean up after merge
-cd ../tool-credit-risk-modelling
-git worktree remove ../credit-risk-new-task
-```
+Use branches by default. For parallel development scenarios (e.g., testing `shared/` changes against apps simultaneously), use the `git-workflow` skill for worktree setup, cleanup procedures, and gotchas.
 
 ### Claude Code Git Permissions
 
@@ -310,47 +213,26 @@ When Pydantic schemas in `shared/` change:
 4. Update `apps/web/` components
 5. Verify `apps/gradio/` field mappings still match API contract
 
-## ADR Creation Checklist
+## Documentation Maintenance
 
-When creating a new Architecture Decision Record:
+### Changelog
 
-### 1. Pick the next number
+- Update `CHANGELOG.md` with every PR that changes user-facing behavior, fixes a bug, or modifies the API surface
+- Entry format: `- [scope] Brief imperative description (#PR)`
+- Valid scopes: `shared`, `api`, `web`, `gradio`, `marimo`, `ci`, `chore`
+- Place entries in `[Unreleased]` under the correct category (Added / Changed / Removed / Fixed / Security)
+- Do NOT add entries for documentation-only, CI-only, or pure refactor PRs
+- Use the `changelog` skill for detailed guidance, templates, and quality checks
 
-```bash
-# Check the highest ADR number on main (not your branch)
-ls docs/1-ADRs/ADR-*.md | sort -V | tail -1
-```
+### Docs
 
-If working in a **worktree** or **parallel branch**, another branch may also be creating an ADR. To avoid numbering conflicts:
+- Update `docs/ENV_VARS.md` when adding or removing environment variables
+- Update `docs/DEPLOYMENT.md` when deployment configuration changes
+- Never leave docs contradicting code — if you change behavior, update the relevant doc in the same PR
 
-- **Check open PRs** for new ADR files: `gh pr list --search "ADR" --state open`
-- **If a conflict is found at merge time**, renumber the later PR's ADR (higher number = later merge)
-- **Never reuse** a number that appeared in a merged PR, even if the file was later deleted
+## ADR Creation
 
-### 2. Create the file
-
-File: `docs/1-ADRs/ADR-NNN-short-description.md`
-
-Required metadata table:
-
-```markdown
-# ADR-NNN: Title
-
-| Field | Value |
-|-------|-------|
-| Status | Proposed |
-| Author | Paul / Claude |
-| Date | YYYY-MM-DD |
-| PR | _Added before merge_ |
-```
-
-Status values: `Proposed` → `Accepted` → `Superseded` (or `Rejected`)
-
-### 3. Before merging the PR
-
-- [ ] Add the `| PR |` link to the ADR metadata table (use the PR number from `gh pr create`)
-- [ ] Add the new ADR to `docs/1-ADRs/README.md` index table
-- [ ] Verify no numbering conflict with other open/recently-merged PRs
+Use the `adr` skill when creating new Architecture Decision Records. Store ADRs in `docs/1-ADRs/`.
 
 ## Do NOT
 
@@ -361,25 +243,37 @@ Status values: `Proposed` → `Accepted` → `Superseded` (or `Rejected`)
 
 ## Skills
 
-Claude Code skills are in `.claude_skills/` (gitignored). Reference them for domain-specific patterns.
+Claude Code skills are in `.claude_skills/`. Reference them for domain-specific patterns.
 
 | Skill | Purpose | Trigger |
 |-------|---------|---------|
 | `rfc` | Write RFC documents | "Write an RFC for...", "Propose..." |
+| `changelog` | Maintain CHANGELOG.md | "Update changelog", "Add changelog entry", releasing a version |
+| `adr` | Create ADR documents | "Create an ADR for...", "Record decision..." |
+| `git-workflow` | Worktree and parallel dev reference | "Set up worktree", "Parallel development", periodic cleanup |
 
-To use a skill, Claude reads the SKILL.md and follows its structure. Skills are local to developer machines and not committed to git.
+To use a skill, Claude reads the SKILL.md and follows its structure.
 
 ### Adding Skills
 
 Place skill folders in `.claude_skills/`:
 
-```
+```text
 .claude_skills/
 ├── rfc/
 │   ├── SKILL.md
 │   └── references/
 │       └── rfc-template.md
-└── [other-skills]/
+├── changelog/
+│   ├── SKILL.md
+│   └── references/
+│       └── changelog-template.md
+├── adr/
+│   ├── SKILL.md
+│   └── references/
+│       └── adr-template.md
+└── git-workflow/
+    └── SKILL.md
 ```
 
 Each skill has a SKILL.md with frontmatter (name, description) and instructions.

--- a/docs/1-ADRs/ADR-README.md
+++ b/docs/1-ADRs/ADR-README.md
@@ -23,4 +23,4 @@ This directory contains Architecture Decision Records (ADRs) for the Credit Risk
 
 ## Creating a New ADR
 
-See the [ADR Creation Checklist](../../CLAUDE.md#adr-creation-checklist) in CLAUDE.md.
+See the [ADR Creation section](../../CLAUDE.md#adr-creation) in CLAUDE.md and the `adr` skill in `.claude_skills/adr/`.


### PR DESCRIPTION
## Summary

- **Backfill CHANGELOG.md** with all 48 PRs using Keep a Changelog format, structured as version 0.1.0
- **Add 3 new Claude Code skills** (changelog, adr, git-workflow) with templates and quality checklists
- **Streamline CLAUDE.md** from 386 → 278 lines by extracting detailed reference material to skills and adding concise documentation maintenance rules
- **Track `.claude_skills/` in git** (removed from .gitignore) so skills are version-controlled and shared

## Changes by commit

1. `docs(changelog)` — Rewrote CHANGELOG.md covering PRs #1-48, grouped by layer and change type
2. `feat(skills)` — Added changelog, adr, and git-workflow skills; un-gitignored `.claude_skills/`; renamed `rfc-skill/` → `rfc/`
3. `docs(claude)` — Added Documentation Maintenance section, extracted ADR checklist and worktree guide to skills, updated Skills table, fixed ADR-README.md cross-reference

## Design decisions

| What stays in CLAUDE.md | What becomes a skill |
|---|---|
| Short imperative rules (always loaded) | Detailed how-to guidance (on-demand) |
| Entry format, valid scopes | Templates, examples, quality checklists |
| Core git workflow, branch hygiene | Worktree setup, parallel dev matrix, gotchas |
| "Use the `adr` skill" (2 lines) | Full creation steps, numbering, conflict avoidance |

## Test plan

- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Verify CLAUDE.md section anchors work (especially `#adr-creation` from ADR-README.md)
- [ ] Verify skill files are present in the PR diff (no longer gitignored)
- [ ] Spot-check changelog entries against merged PR titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)