### PR TITLE
chore: extract fastapi-crud-endpoint and recharts-chart skills

### DIFF
--- a/.claude_skills/fastapi-crud-endpoint/SKILL.md
+++ b/.claude_skills/fastapi-crud-endpoint/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: fastapi-crud-endpoint
+description: Create new FastAPI CRUD endpoints following the project's proven router patterns (auth, rate limiting, error handling, Pydantic v2 schemas).
+---
+
+# FastAPI CRUD Endpoint Skill
+
+Generate new API endpoints that match the conventions established across the 5 existing routers (`auth`, `predict`, `train`, `models`, `feature_selection`).
+
+## When to Use
+
+- Adding a new router to `apps/api/routers/`
+- Adding endpoints to an existing router
+- Creating a new service + router pair
+
+## When NOT to Use
+
+- Modifying shared Pydantic schemas only (no endpoint changes)
+- Changing middleware or app-level configuration
+
+## Endpoint Patterns
+
+This project uses four endpoint shapes. Pick the one that fits, then follow the template in `references/router-template.py`.
+
+### Pattern 1 — GET List
+
+Return a collection. No auth required (read-only).
+
+```python
+@router.get("/", response_model=list[ItemSchema])
+async def list_items() -> list[ItemSchema]:
+```
+
+### Pattern 2 — GET by ID
+
+Return a single resource. Raise 404 if missing.
+
+```python
+@router.get("/{item_id}", response_model=ItemSchema)
+async def get_item(item_id: str) -> ItemSchema:
+```
+
+### Pattern 3 — POST Create / Action
+
+Accept a Pydantic request body, return a Pydantic response. Requires auth + optional rate limiting.
+
+```python
+@router.post("/", response_model=ResponseSchema)
+@limiter.limit("100/minute")
+async def create_item(
+    request: Request,
+    payload: RequestSchema,
+    settings: Settings = Depends(get_settings),
+    _api_key: str = Depends(verify_api_key),
+) -> ResponseSchema:
+```
+
+### Pattern 4 — POST Sub-action on Resource
+
+Perform an action on an existing resource (e.g., `/models/{id}/persist`).
+
+```python
+@router.post("/{item_id}/action", response_model=ResponseSchema)
+async def perform_action(
+    item_id: str,
+    settings: Settings = Depends(get_settings),
+    _api_key: str = Depends(verify_api_key),
+) -> ResponseSchema:
+```
+
+## Creation Steps
+
+1. **Define Pydantic schemas** in `shared/schemas/<domain>.py`
+   - Request model (if POST) and Response model
+   - Use `Field()` for validation and OpenAPI docs
+   - Run `uv run pytest tests/shared/` after changes
+
+2. **Create the service** in `apps/api/services/<domain>.py`
+   - Pure business logic, no FastAPI imports
+   - Accept typed inputs, return Pydantic models
+   - Raise `ValueError` for bad input, `FileNotFoundError` for missing resources
+
+3. **Create the router** in `apps/api/routers/<domain>.py`
+   - Follow the template in `references/router-template.py`
+   - Module docstring: `"""<Domain> endpoint router."""`
+   - Single `router = APIRouter()` at module level
+
+4. **Register the router** in `apps/api/main.py`
+   ```python
+   from apps.api.routers import new_domain
+   app.include_router(
+       new_domain.router,
+       prefix="/new-domain",
+       tags=["new-domain"],
+   )
+   ```
+
+5. **Add tests** in `tests/api/test_<domain>.py`
+   - Use `httpx.AsyncClient` with the app fixture
+   - Test happy path, 400, 404, and 500 cases
+
+## Conventions
+
+### Dependency Order (in function signature)
+
+1. Path parameters (`item_id: str`)
+2. Request body (`payload: RequestSchema`)
+3. `request: Request` (only if rate limiting is used)
+4. `settings: Settings = Depends(get_settings)` (if needed)
+5. `_api_key: str = Depends(verify_api_key)` (if write endpoint)
+
+### Error Handling
+
+Every POST endpoint uses this hierarchy:
+
+```python
+try:
+    result = service_function(...)
+    return result
+except FileNotFoundError:
+    logger.exception("Resource not found")
+    raise HTTPException(status_code=404, detail="Resource not found")
+except ValueError:
+    logger.exception("Invalid input")
+    raise HTTPException(status_code=400, detail="Invalid configuration")
+except Exception:
+    logger.exception("Operation failed unexpectedly")
+    raise HTTPException(status_code=500, detail="Internal server error")
+```
+
+### Rate Limiting
+
+- Heavy compute (training, feature selection): `"10/hour"` or `"20/hour"`
+- Standard endpoints (predictions): `"100/minute"`
+- Read-only endpoints: no rate limit
+
+### Logging
+
+- `logger = logging.getLogger(__name__)` at module level
+- Use `logger.exception()` inside except blocks (auto-attaches traceback)
+
+### Docstrings
+
+Every endpoint needs:
+- One-line summary
+- `Args:` section
+- `Returns:` section
+- `Raises:` section listing HTTPException codes
+- `Example Request:` / `Example Response:` JSON blocks (for POST endpoints)
+
+## Checklist
+
+- [ ] Pydantic schemas defined in `shared/schemas/`
+- [ ] Service created in `apps/api/services/`
+- [ ] Router created using template pattern
+- [ ] Router registered in `apps/api/main.py` with prefix and tags
+- [ ] Docstrings with Args/Returns/Raises/Examples
+- [ ] Error handling follows the 404/400/500 hierarchy
+- [ ] Auth dependency added for write endpoints
+- [ ] Rate limiting added for compute-heavy endpoints
+- [ ] Tests cover happy path + error cases
+- [ ] `uv run pytest` passes

--- a/.claude_skills/fastapi-crud-endpoint/references/router-template.py
+++ b/.claude_skills/fastapi-crud-endpoint/references/router-template.py
@@ -1,0 +1,144 @@
+"""<Domain> endpoint router."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from apps.api.auth import verify_api_key
+from apps.api.config import Settings
+from apps.api.dependencies import get_settings
+from apps.api.middleware.rate_limit import limiter
+
+# Import Pydantic schemas from shared/
+# from shared.schemas.<domain> import <RequestSchema>, <ResponseSchema>
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# --- Pattern 1: GET List (no auth) ---
+
+
+# @router.get("/", response_model=list[ItemSchema])
+# async def list_items() -> list[ItemSchema]:
+#     """List all items.
+#
+#     Returns:
+#         List of item metadata.
+#
+#     Example Response:
+#         ```json
+#         [{"id": "item_abc123", "name": "Example"}]
+#         ```
+#     """
+#     return get_all_items()
+
+
+# --- Pattern 2: GET by ID (no auth) ---
+
+
+# @router.get("/{item_id}", response_model=ItemSchema)
+# async def get_item(item_id: str) -> ItemSchema:
+#     """Get a specific item by ID.
+#
+#     Args:
+#         item_id: Unique identifier.
+#
+#     Returns:
+#         Item details.
+#
+#     Raises:
+#         HTTPException: 404 if item not found.
+#     """
+#     item = find_item(item_id)
+#     if item is None:
+#         raise HTTPException(status_code=404, detail=f"Not found: {item_id}")
+#     return item
+
+
+# --- Pattern 3: POST Create/Action (auth + rate limit) ---
+
+
+# @router.post("/", response_model=ResponseSchema)
+# @limiter.limit("100/minute")
+# async def create_item(
+#     request: Request,
+#     payload: RequestSchema,
+#     settings: Settings = Depends(get_settings),
+#     _api_key: str = Depends(verify_api_key),
+# ) -> ResponseSchema:
+#     """Create a new item.
+#
+#     Args:
+#         request: FastAPI request (for rate limiting).
+#         payload: Creation parameters.
+#         settings: Application settings (injected).
+#
+#     Returns:
+#         Created item with full details.
+#
+#     Raises:
+#         HTTPException: 400 for invalid input, 404 for missing resource,
+#             500 for unexpected errors.
+#
+#     Example Request:
+#         ```json
+#         {"name": "Example", "value": 42}
+#         ```
+#
+#     Example Response:
+#         ```json
+#         {"id": "item_abc123", "name": "Example", "value": 42}
+#         ```
+#     """
+#     try:
+#         result = service_function(payload, settings=settings)
+#         return result
+#     except FileNotFoundError:
+#         logger.exception("Resource not found")
+#         raise HTTPException(status_code=404, detail="Resource not found")
+#     except ValueError:
+#         logger.exception("Invalid input")
+#         raise HTTPException(status_code=400, detail="Invalid configuration")
+#     except Exception:
+#         logger.exception("Operation failed unexpectedly")
+#         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# --- Pattern 4: POST Sub-action on Resource (auth, no body) ---
+
+
+# @router.post("/{item_id}/action", response_model=ActionResponseSchema)
+# async def perform_action(
+#     item_id: str,
+#     settings: Settings = Depends(get_settings),
+#     _api_key: str = Depends(verify_api_key),
+# ) -> ActionResponseSchema:
+#     """Perform action on a specific item.
+#
+#     Args:
+#         item_id: Target item identifier.
+#         settings: Application settings (injected).
+#
+#     Returns:
+#         Action result.
+#
+#     Raises:
+#         HTTPException: 404 if item not found, 500 if action fails.
+#
+#     Example Response:
+#         ```json
+#         {"item_id": "item_abc123", "status": "completed"}
+#         ```
+#     """
+#     item = find_item(item_id)
+#     if item is None:
+#         raise HTTPException(status_code=404, detail=f"Not found: {item_id}")
+#
+#     try:
+#         result = action_service(item, settings=settings)
+#         return result
+#     except Exception:
+#         logger.exception("Action failed for %s", item_id)
+#         raise HTTPException(status_code=500, detail="Action failed")

--- a/.claude_skills/recharts-chart/SKILL.md
+++ b/.claude_skills/recharts-chart/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: recharts-chart
+description: Create new Recharts visualization components following the project's proven chart patterns (responsive, typed, dark-mode compatible).
+---
+
+# Recharts Chart Skill
+
+Generate new chart components that match the conventions established across the 3 existing Recharts chart types (`ROCCurve`, `CalibrationPlot`, `MetricsBar`) in `apps/web/components/charts/`.
+
+## When to Use
+
+- Adding a new visualization to the Next.js dashboard
+- Creating a chart component for a new model metric
+- Building single-series or multi-series comparisons
+
+## When NOT to Use
+
+- Non-chart UI components (use shadcn/ui patterns instead)
+- Custom HTML visualizations like the confusion matrix grid
+- Charts that don't use Recharts (e.g., D3-only)
+
+## Chart Types Available
+
+| Recharts Component | Use When | Example in Codebase |
+|--------------------|----------|---------------------|
+| `LineChart` | Continuous x-y data, curves | ROC curve, calibration plot |
+| `BarChart` | Categorical comparisons | Metrics comparison across models |
+| `AreaChart` | Line with filled region | Probability distributions |
+| `ScatterChart` | Discrete x-y points | Feature importance scatter |
+
+## Creation Steps
+
+1. **Define the TypeScript interface** in `apps/web/lib/types.ts`
+   - Match the Pydantic schema structure from `shared/schemas/`
+   - Use arrays for series data (e.g., `fpr: number[]`, `tpr: number[]`)
+
+2. **Create the component** in `apps/web/components/charts/<name>.tsx`
+   - Follow the template in `references/chart-template.tsx`
+   - Start with `"use client"` directive
+   - Single default or named export
+
+3. **Add data transformation** (if needed)
+   - Transform parallel arrays into Recharts point objects inside the component
+   - Keep transformation minimal; prefer shaping data at the page level
+
+4. **Integrate into a page**
+   - Wrap in a `<Card>` component with a descriptive title
+   - Pass typed props from API response data
+
+## Conventions
+
+### Component Structure
+
+Every chart component follows this order:
+
+```tsx
+"use client";
+
+// 1. Recharts imports (destructured)
+import { CartesianGrid, Line, LineChart, ... } from "recharts";
+
+// 2. Type imports
+import type { DataType } from "@/lib/types";
+
+// 3. Props interface
+interface ChartNameProps { ... }
+
+// 4. Constants (colors, labels)
+const COLORS = ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c"];
+
+// 5. Component function
+export function ChartName({ data }: ChartNameProps) { ... }
+```
+
+### Dimensions
+
+- **Height**: Always `350` via `ResponsiveContainer`
+- **Width**: Always `"100%"` via `ResponsiveContainer`
+- **Margins** (with axis labels): `{ top: 5, right: 20, bottom: 25, left: 10 }`
+- **Margins** (without axis labels): `{ top: 5, right: 20, bottom: 5, left: 10 }`
+
+### Color Palette
+
+```typescript
+const COLORS = ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c"];
+//               blue        red        green      purple     orange
+```
+
+- Primary single-series color: `#2563eb`
+- Multi-series: index into `COLORS[idx % COLORS.length]`
+- Reference lines / guides: `#9ca3af` (gray-400)
+
+### Grid and Axes
+
+```tsx
+<CartesianGrid strokeDasharray="3 3" />
+```
+
+**Numeric 0–1 axis** (probabilities, rates):
+
+```tsx
+<XAxis
+    dataKey="fieldName"
+    type="number"
+    domain={[0, 1]}
+    label={{ value: "Axis Label", position: "insideBottom", offset: -15 }}
+/>
+<YAxis
+    domain={[0, 1]}
+    label={{ value: "Axis Label", angle: -90, position: "insideLeft" }}
+/>
+```
+
+**Categorical axis** (metric names, categories):
+
+```tsx
+<XAxis dataKey="category" />
+<YAxis domain={[0, 1]} />
+```
+
+### Tooltip
+
+Standard formatter for numeric values:
+
+```tsx
+<Tooltip formatter={(value: number | undefined) => value?.toFixed(4) ?? ""} />
+```
+
+With custom label:
+
+```tsx
+<Tooltip
+    formatter={(value: number | undefined) => value?.toFixed(4) ?? ""}
+    labelFormatter={(label) => `Label: ${Number(label).toFixed(4)}`}
+/>
+```
+
+### Line Styling
+
+```tsx
+<Line
+    name="Series Label"
+    type="monotone"
+    dataKey="fieldName"
+    stroke="#2563eb"
+    dot={false}           // false for dense data, { r: 4 } for sparse
+    strokeWidth={2}
+/>
+```
+
+### Reference Lines (diagonal, threshold markers)
+
+```tsx
+<ReferenceLine
+    segment={[{ x: 0, y: 0 }, { x: 1, y: 1 }]}
+    stroke="#9ca3af"
+    strokeDasharray="5 5"
+    label="Random"
+/>
+```
+
+### Data Transformation
+
+Transform parallel arrays into Recharts point objects:
+
+```tsx
+// Input: { fpr: number[], tpr: number[] }
+const chartData = data.fpr.map((fpr, i) => ({
+    fpr,
+    tpr: data.tpr[i],
+}));
+```
+
+Pivot models into comparison data:
+
+```tsx
+// Input: models[] with metric fields
+const chartData = metrics.map((metric) => {
+    const point: Record<string, string | number> = { metric: labels[metric] };
+    for (const model of models) {
+        point[model.name] = Number(model[metric].toFixed(4));
+    }
+    return point;
+});
+```
+
+### Multi-Series (Dynamic)
+
+```tsx
+{items.map((item, idx) => (
+    <Line
+        key={item.label}
+        name={item.label}
+        dataKey="y"
+        stroke={item.color || COLORS[idx % COLORS.length]}
+        dot={false}
+        strokeWidth={2}
+    />
+))}
+```
+
+## Checklist
+
+- [ ] `"use client"` directive at top of file
+- [ ] Props interface defined with proper types
+- [ ] `ResponsiveContainer` wrapping with `width="100%"` and `height={350}`
+- [ ] `CartesianGrid strokeDasharray="3 3"`
+- [ ] Axes with labels (if applicable) using project conventions
+- [ ] Tooltip with `.toFixed(4)` formatter
+- [ ] Uses project color palette (`COLORS` array or `#2563eb` primary)
+- [ ] Data type added to `apps/web/lib/types.ts` (if new)
+- [ ] Component exported as named export
+- [ ] Integrated into page wrapped in `<Card>`

--- a/.claude_skills/recharts-chart/references/chart-template.tsx
+++ b/.claude_skills/recharts-chart/references/chart-template.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import {
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+// import type { DataType } from "@/lib/types";
+
+// --- 1. Props Interface ---
+
+interface ChartNameProps {
+	data: {
+		xValues: number[];
+		yValues: number[];
+	};
+	label?: string;
+	color?: string;
+}
+
+// --- 2. Color Palette (for multi-series) ---
+
+// const COLORS = ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c"];
+
+// --- 3. Component ---
+
+export function ChartName({
+	data,
+	label = "Series",
+	color = "#2563eb",
+}: ChartNameProps) {
+	// Transform parallel arrays into Recharts point objects
+	const chartData = data.xValues.map((x, i) => ({
+		x,
+		y: data.yValues[i],
+	}));
+
+	return (
+		<ResponsiveContainer width="100%" height={350}>
+			<LineChart
+				data={chartData}
+				margin={{ top: 5, right: 20, bottom: 25, left: 10 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" />
+				<XAxis
+					dataKey="x"
+					type="number"
+					domain={[0, 1]}
+					label={{
+						value: "X Axis Label",
+						position: "insideBottom",
+						offset: -15,
+					}}
+				/>
+				<YAxis
+					domain={[0, 1]}
+					label={{
+						value: "Y Axis Label",
+						angle: -90,
+						position: "insideLeft",
+					}}
+				/>
+				<Tooltip
+					formatter={(value: number | undefined) =>
+						value?.toFixed(4) ?? ""
+					}
+				/>
+				<Legend verticalAlign="top" />
+				<Line
+					name={label}
+					type="monotone"
+					dataKey="y"
+					stroke={color}
+					dot={false}
+					strokeWidth={2}
+				/>
+			</LineChart>
+		</ResponsiveContainer>
+	);
+}
+
+// --- Multi-series variant ---
+
+// interface MultiChartNameProps {
+// 	series: { data: DataType; label: string; color: string }[];
+// }
+//
+// export function MultiChartName({ series }: MultiChartNameProps) {
+// 	return (
+// 		<ResponsiveContainer width="100%" height={350}>
+// 			<LineChart margin={{ top: 5, right: 20, bottom: 25, left: 10 }}>
+// 				<CartesianGrid strokeDasharray="3 3" />
+// 				<XAxis type="number" domain={[0, 1]}
+// 					label={{ value: "X Axis Label", position: "insideBottom", offset: -15 }}
+// 				/>
+// 				<YAxis domain={[0, 1]}
+// 					label={{ value: "Y Axis Label", angle: -90, position: "insideLeft" }}
+// 				/>
+// 				<Tooltip formatter={(value: number | undefined) => value?.toFixed(4) ?? ""} />
+// 				<Legend verticalAlign="top" />
+// 				{series.map((s, idx) => {
+// 					const points = s.data.xValues.map((x, i) => ({
+// 						x,
+// 						y: s.data.yValues[i],
+// 					}));
+// 					return (
+// 						<Line
+// 							key={s.label}
+// 							name={s.label}
+// 							data={points}
+// 							type="monotone"
+// 							dataKey="y"
+// 							stroke={s.color || COLORS[idx % COLORS.length]}
+// 							dot={false}
+// 							strokeWidth={2}
+// 						/>
+// 					);
+// 				})}
+// 			</LineChart>
+// 		</ResponsiveContainer>
+// 	);
+// }
+
+// --- BarChart variant ---
+
+// interface MetricsBarProps {
+// 	items: { name: string; [metric: string]: string | number }[];
+// }
+//
+// export function MetricsBarChart({ items }: MetricsBarProps) {
+// 	return (
+// 		<ResponsiveContainer width="100%" height={350}>
+// 			<BarChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+// 				<CartesianGrid strokeDasharray="3 3" />
+// 				<XAxis dataKey="category" />
+// 				<YAxis domain={[0, 1]} />
+// 				<Tooltip formatter={(value: number | undefined) => value?.toFixed(4) ?? ""} />
+// 				<Legend />
+// 				{items.map((item, idx) => (
+// 					<Bar key={item.name} dataKey={item.name} fill={COLORS[idx % COLORS.length]} />
+// 				))}
+// 			</BarChart>
+// 		</ResponsiveContainer>
+// 	);
+// }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,8 @@ Claude Code skills are in `.claude_skills/`. Reference them for domain-specific 
 | `changelog` | Maintain CHANGELOG.md | "Update changelog", "Add changelog entry", releasing a version |
 | `adr` | Create ADR documents | "Create an ADR for...", "Record decision..." |
 | `git-workflow` | Worktree and parallel dev reference | "Set up worktree", "Parallel development", periodic cleanup |
+| `fastapi-crud-endpoint` | Create new API endpoints | "Add endpoint for...", "New router for..." |
+| `recharts-chart` | Create new chart visualizations | "Add chart for...", "New visualization for..." |
 
 To use a skill, Claude reads the SKILL.md and follows its structure.
 
@@ -272,8 +274,16 @@ Place skill folders in `.claude_skills/`:
 │   ├── SKILL.md
 │   └── references/
 │       └── adr-template.md
-└── git-workflow/
-    └── SKILL.md
+├── git-workflow/
+│   └── SKILL.md
+├── fastapi-crud-endpoint/
+│   ├── SKILL.md
+│   └── references/
+│       └── router-template.py
+└── recharts-chart/
+    ├── SKILL.md
+    └── references/
+        └── chart-template.tsx
 ```
 
 Each skill has a SKILL.md with frontmatter (name, description) and instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 [tool.ruff]
 line-length = 88
 target-version = "py312"
+exclude = [".claude_skills/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]


### PR DESCRIPTION
## Summary
- Extract `fastapi-crud-endpoint` skill from patterns proven across 5 API routers (auth, predict, train, models, feature_selection) — covers GET list, GET by ID, POST create, and POST sub-action patterns
- Extract `recharts-chart` skill from patterns proven across 3 chart types (ROC curve, calibration plot, metrics bar) — covers dimensions, colors, axes, tooltips, and multi-series conventions
- Update CLAUDE.md skills table and directory listing

## Test plan
- [ ] Verify skill SKILL.md files follow existing frontmatter format (name, description)
- [ ] Verify reference templates match actual codebase patterns
- [ ] Verify CLAUDE.md skills table renders correctly
- [ ] Use `fastapi-crud-endpoint` skill to scaffold a new endpoint and confirm output matches conventions
- [ ] Use `recharts-chart` skill to scaffold a new chart and confirm output matches conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)