### PR TITLE
fix(web): resolve input validation, ROC axis, and model ID overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [web] Number input step validation rejecting valid income, employment length, and loan amount values
+- [web] Compare page ROC curve X-axis showing array indices instead of false positive rate
+- [web] Model ID text overflow on home page and training summary on mobile viewports
+
 ## [0.1.0] - 2026-02-11
 
 Initial release — migrated from a Streamlit prototype to a production-grade monorepo

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -82,11 +82,13 @@ export default function Home() {
 						{models.map((model) => (
 							<div
 								key={model.model_id}
-								className="flex items-center justify-between rounded-md border border-border px-4 py-2"
+								className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border px-4 py-2"
 							>
-								<div>
+								<div className="min-w-0">
 									<span className="font-medium text-foreground">{model.model_type}</span>
-									<span className="ml-2 text-sm text-foreground-muted">{model.model_id}</span>
+									<span className="ml-2 text-sm text-foreground-muted" title={model.model_id}>
+										{model.model_id.slice(0, 8)}
+									</span>
 								</div>
 								<div className="text-sm text-foreground-secondary">
 									AUC: {model.roc_auc.toFixed(3)} | Acc: {model.accuracy.toFixed(3)}

--- a/apps/web/app/train/page.tsx
+++ b/apps/web/app/train/page.tsx
@@ -132,9 +132,11 @@ export default function TrainPage() {
 						<>
 							<Card title="Training Summary">
 								<div className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
-									<div>
+									<div className="min-w-0">
 										<span className="text-foreground-muted">Model ID</span>
-										<p className="font-mono text-xs">{result.model_id}</p>
+										<p className="truncate font-mono text-xs" title={result.model_id}>
+											{result.model_id.slice(0, 8)}
+										</p>
 									</div>
 									<div>
 										<span className="text-foreground-muted">Type</span>

--- a/apps/web/components/charts/roc-curve.tsx
+++ b/apps/web/components/charts/roc-curve.tsx
@@ -79,6 +79,7 @@ export function MultiROCCurve({ curves }: MultiROCCurveProps) {
 			<LineChart margin={{ top: 5, right: 20, bottom: 25, left: 10 }}>
 				<CartesianGrid strokeDasharray="3 3" />
 				<XAxis
+					dataKey="x"
 					type="number"
 					domain={[0, 1]}
 					label={{ value: "False Positive Rate", position: "insideBottom", offset: -15 }}

--- a/apps/web/components/forms/loan-fields.tsx
+++ b/apps/web/components/forms/loan-fields.tsx
@@ -57,7 +57,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 				label="Annual Income"
 				type="number"
 				min={1}
-				step={1000}
+				step="any"
 				value={values.person_income}
 				onChange={(e) => onChange("person_income", Number(e.target.value))}
 				error={errors.person_income}
@@ -66,7 +66,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 				label="Employment Length (years)"
 				type="number"
 				min={0}
-				step={0.5}
+				step="any"
 				value={values.person_emp_length}
 				onChange={(e) => onChange("person_emp_length", Number(e.target.value))}
 				error={errors.person_emp_length}
@@ -75,7 +75,7 @@ export function LoanFields({ values, onChange, errors = {} }: LoanFieldsProps) {
 				label="Loan Amount"
 				type="number"
 				min={1}
-				step={500}
+				step="any"
 				value={values.loan_amnt}
 				onChange={(e) => onChange("loan_amnt", Number(e.target.value))}
 				error={errors.loan_amnt}


### PR DESCRIPTION
## Summary

- **Input step validation**: Changed `step` to `"any"` on Annual Income, Employment Length, and Loan Amount inputs. HTML5 `step` + `min` validation was rejecting valid values (e.g. 50000 was invalid with `step=1000` and `min=1` — nearest valid: 49001, 50001)
- **ROC curve X-axis**: Added `dataKey="x"` to `MultiROCCurve` XAxis so Recharts plots actual FPR values instead of array indices (was showing 0–3000+ instead of 0–1)
- **Model ID overflow**: Truncated model IDs to 8 chars on home page and training summary (matching compare page convention), added `flex-wrap`/`min-w-0` for mobile layout, and `title` tooltip for full UUID on hover

## Test plan

- [ ] Open `/predict`, enter 50000 in Annual Income — no browser validation error
- [ ] Open `/compare`, compare 2+ models — ROC curve X-axis shows 0 to 1.0
- [ ] View home page and training summary at 375px mobile width — model IDs truncated, metrics visible
- [ ] `npm run build` passes in `apps/web/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)