### PR TITLE
feat(shared): add synthetic data generation schemas and logic

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -1,5 +1,7 @@
 """Constants for credit risk modeling."""
 
+from typing import Any
+
 # Feature definitions based on cr_loan_w2.csv dataset
 
 NUMERIC_FEATURES: list[str] = [
@@ -180,6 +182,133 @@ IV_THRESHOLD_STRONG: float = 0.5
 # Boruta defaults
 BORUTA_DEFAULT_N_ITERATIONS: int = 100
 BORUTA_DEFAULT_CONFIDENCE_LEVEL: float = 0.95
+
+# ---------------------------------------------------------------------------
+# Synthetic data generation defaults
+# ---------------------------------------------------------------------------
+# Approximate real-dataset distributions for synthetic generation.
+# Derived from cr_loan_w2.csv (29,459 rows).
+
+NUMERIC_FEATURE_DEFAULTS: dict[str, dict[str, float]] = {
+    "person_age": {
+        "mean": 27.7001,
+        "std": 6.1654,
+        "min": 20.0,
+        "max": 84.0,
+    },
+    "person_income": {
+        "mean": 65803.7326,
+        "std": 51331.0957,
+        "min": 4000.0,
+        "max": 2039784.0,
+    },
+    "person_emp_length": {
+        "mean": 4.7584,
+        "std": 3.9807,
+        "min": 0.0,
+        "max": 41.0,
+    },
+    "loan_amnt": {
+        "mean": 9583.6009,
+        "std": 6314.421,
+        "min": 500.0,
+        "max": 35000.0,
+    },
+    "loan_int_rate": {
+        "mean": 11.0115,
+        "std": 3.2405,
+        "min": 5.42,
+        "max": 23.22,
+    },
+    "loan_percent_income": {
+        "mean": 0.1701,
+        "std": 0.1068,
+        "min": 0.0,
+        "max": 0.83,
+    },
+    "cb_person_cred_hist_length": {
+        "mean": 5.7881,
+        "std": 4.0307,
+        "min": 2.0,
+        "max": 30.0,
+    },
+}
+
+CATEGORICAL_FEATURE_DEFAULTS: dict[str, dict[str, float]] = {
+    "person_home_ownership": {
+        "MORTGAGE": 0.4114,
+        "OTHER": 0.0032,
+        "OWN": 0.08,
+        "RENT": 0.5054,
+    },
+    "loan_intent": {
+        "DEBTCONSOLIDATION": 0.1596,
+        "EDUCATION": 0.1986,
+        "HOMEIMPROVEMENT": 0.1117,
+        "MEDICAL": 0.185,
+        "PERSONAL": 0.1701,
+        "VENTURE": 0.1749,
+    },
+    "loan_grade": {
+        "A": 0.3317,
+        "B": 0.3188,
+        "C": 0.1978,
+        "D": 0.1125,
+        "E": 0.0299,
+        "F": 0.0073,
+        "G": 0.002,
+    },
+    "cb_person_default_on_file": {
+        "N": 0.8231,
+        "Y": 0.1769,
+    },
+}
+
+# Correlation matrix for numeric features (preserves inter-feature relationships).
+# Row/column order matches NUMERIC_FEATURES.
+NUMERIC_CORRELATION_MATRIX: list[list[float]] = [
+    # fmt: off
+    [1.0, 0.1404, 0.174, 0.0558, 0.012, -0.0407, 0.8774],
+    [0.1404, 1.0, 0.1616, 0.3276, -0.0011, -0.2987, 0.1217],
+    [0.174, 0.1616, 1.0, 0.1092, -0.0556, -0.0601, 0.1498],
+    [0.0558, 0.3276, 0.1092, 1.0, 0.1468, 0.5725, 0.0455],
+    [0.012, -0.0011, -0.0556, 0.1468, 1.0, 0.1202, 0.0167],
+    [-0.0407, -0.2987, -0.0601, 0.5725, 0.1202, 1.0, -0.0303],
+    [0.8774, 0.1217, 0.1498, 0.0455, 0.0167, -0.0303, 1.0],
+    # fmt: on
+]
+
+# Named presets for synthetic data generation.
+# Keys are human-readable names; values are partial SyntheticConfig dicts.
+SYNTHETIC_PRESETS: dict[str, dict[str, Any]] = {
+    "Stress Test": {
+        "n_samples": 5000,
+        "default_rate": 0.50,
+        "distributions": [
+            {"feature": "person_income", "mean_shift": -15000.0, "std_scale": 1.5},
+            {
+                "feature": "loan_int_rate",
+                "mean_shift": 4.0,
+                "std_scale": 1.2,
+            },
+            {
+                "feature": "loan_grade",
+                "category_weights": {
+                    "A": 0.05,
+                    "B": 0.10,
+                    "C": 0.20,
+                    "D": 0.25,
+                    "E": 0.20,
+                    "F": 0.15,
+                    "G": 0.05,
+                },
+            },
+        ],
+    },
+    "Low Default": {"n_samples": 5000, "default_rate": 0.05},
+    "Large Sample": {"n_samples": 50000, "default_rate": 0.22},
+    "Balanced": {"n_samples": 5000, "default_rate": 0.50},
+}
 
 # Chart color palette (shared across all notebooks and apps)
 COLOR_PRIMARY: str = "#636EFA"

--- a/shared/logic/__init__.py
+++ b/shared/logic/__init__.py
@@ -18,6 +18,7 @@ from shared.logic.preprocessing import (
     loan_application_to_feature_vector,
     undersample_majority_class,
 )
+from shared.logic.synthetic import generate_synthetic_dataset
 from shared.logic.threshold import evaluate_threshold, find_optimal_threshold
 
 __all__ = [
@@ -37,6 +38,8 @@ __all__ = [
     "encode_loan_intent",
     "loan_application_to_feature_vector",
     "undersample_majority_class",
+    # Synthetic
+    "generate_synthetic_dataset",
     # Threshold
     "evaluate_threshold",
     "find_optimal_threshold",

--- a/shared/logic/synthetic.py
+++ b/shared/logic/synthetic.py
@@ -1,0 +1,163 @@
+"""Synthetic credit risk data generator.
+
+Generates datasets in the same format as ``load_dataset_from_csv()`` using
+multivariate normal sampling for numeric features (preserving real-dataset
+correlations) and multinomial sampling for categorical features.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from shared.constants import (
+    ALL_FEATURES,
+    CATEGORICAL_FEATURE_DEFAULTS,
+    CATEGORICAL_FEATURES,
+    FEATURE_GROUPS,
+    NUMERIC_CORRELATION_MATRIX,
+    NUMERIC_FEATURE_DEFAULTS,
+    NUMERIC_FEATURES,
+)
+from shared.schemas.synthetic import SyntheticConfig, SyntheticDataset
+
+
+def generate_synthetic_dataset(
+    config: SyntheticConfig,
+) -> tuple[NDArray[np.float64], NDArray[np.int_], list[str], SyntheticDataset]:
+    """Generate a synthetic credit risk dataset.
+
+    Uses multivariate normal sampling for numeric features (preserving
+    correlations from the real dataset) and multinomial sampling for
+    categorical features.
+
+    Args:
+        config: Generation configuration.
+
+    Returns:
+        Tuple of (X, y, feature_names, metadata).
+
+    Raises:
+        ValueError: If a distribution override references an unknown feature.
+    """
+    _validate_overrides(config)
+
+    rng = np.random.default_rng(config.random_seed)
+
+    # --- Target labels ---
+    n_defaults = round(config.n_samples * config.default_rate)
+    y = np.zeros(config.n_samples, dtype=np.int_)
+    y[:n_defaults] = 1
+    rng.shuffle(y)
+
+    # --- Build override lookup ---
+    overrides = {d.feature: d for d in config.distributions}
+
+    # --- Numeric features (correlated multivariate normal) ---
+    means = np.array(
+        [NUMERIC_FEATURE_DEFAULTS[f]["mean"] for f in NUMERIC_FEATURES],
+        dtype=np.float64,
+    )
+    stds = np.array(
+        [NUMERIC_FEATURE_DEFAULTS[f]["std"] for f in NUMERIC_FEATURES],
+        dtype=np.float64,
+    )
+
+    # Apply overrides to means and stds
+    for i, feat in enumerate(NUMERIC_FEATURES):
+        if feat in overrides:
+            means[i] += overrides[feat].mean_shift
+            stds[i] *= overrides[feat].std_scale
+
+    # Build covariance matrix: cov[i,j] = corr[i,j] * std_i * std_j
+    corr = np.array(NUMERIC_CORRELATION_MATRIX, dtype=np.float64)
+    cov = corr * np.outer(stds, stds)
+
+    # Sample and clip to valid bounds
+    numeric_data = rng.multivariate_normal(means, cov, config.n_samples)
+    for i, feat in enumerate(NUMERIC_FEATURES):
+        bounds = NUMERIC_FEATURE_DEFAULTS[feat]
+        numeric_data[:, i] = np.clip(numeric_data[:, i], bounds["min"], bounds["max"])
+
+    # --- Categorical features (one-hot encoded via multinomial sampling) ---
+    categorical_columns: dict[str, NDArray[np.float64]] = {}
+
+    for cat_feat in CATEGORICAL_FEATURES:
+        encoded_cols = FEATURE_GROUPS[cat_feat]
+        defaults = CATEGORICAL_FEATURE_DEFAULTS[cat_feat]
+
+        # Category names are the suffix after the last underscore grouping
+        # e.g. "person_home_ownership_RENT" -> "RENT"
+        prefix = cat_feat + "_"
+        categories = [col[len(prefix) :] for col in encoded_cols]
+
+        # Get weights (apply override if present)
+        override = overrides.get(cat_feat)
+        if override is not None and override.category_weights is not None:
+            ow = override.category_weights
+            weights = np.array(
+                [ow.get(c, defaults.get(c, 0.0)) for c in categories],
+                dtype=np.float64,
+            )
+        else:
+            weights = np.array([defaults[c] for c in categories], dtype=np.float64)
+
+        # Normalize weights to sum to 1.0
+        weights = weights / weights.sum()
+
+        # Sample categories
+        chosen = rng.choice(len(categories), size=config.n_samples, p=weights)
+
+        # One-hot encode
+        one_hot = np.zeros((config.n_samples, len(categories)), dtype=np.float64)
+        one_hot[np.arange(config.n_samples), chosen] = 1.0
+
+        for j, col_name in enumerate(encoded_cols):
+            categorical_columns[col_name] = one_hot[:, j]
+
+    # --- Assemble into (n_samples, 26) matrix in ALL_FEATURES order ---
+    X = np.empty((config.n_samples, len(ALL_FEATURES)), dtype=np.float64)  # noqa: N806
+    for col_idx, feat_name in enumerate(ALL_FEATURES):
+        if feat_name in NUMERIC_FEATURES:
+            num_idx = NUMERIC_FEATURES.index(feat_name)
+            X[:, col_idx] = numeric_data[:, num_idx]
+        else:
+            X[:, col_idx] = categorical_columns[feat_name]
+
+    # --- Compute metadata ---
+    summary_stats: dict[str, dict[str, float]] = {}
+    for col_idx, feat_name in enumerate(ALL_FEATURES):
+        col = X[:, col_idx]
+        summary_stats[feat_name] = {
+            "mean": float(np.mean(col)),
+            "std": float(np.std(col)),
+            "min": float(np.min(col)),
+            "max": float(np.max(col)),
+        }
+
+    actual_default_rate = float(np.mean(y))
+    metadata = SyntheticDataset(
+        n_samples=config.n_samples,
+        n_features=len(ALL_FEATURES),
+        default_rate_actual=round(actual_default_rate, 4),
+        feature_names=list(ALL_FEATURES),
+        summary_stats=summary_stats,
+    )
+
+    return X, y, list(ALL_FEATURES), metadata
+
+
+def _validate_overrides(config: SyntheticConfig) -> None:
+    """Validate that all distribution override feature names are known.
+
+    Args:
+        config: Generation configuration to validate.
+
+    Raises:
+        ValueError: If an override references an unknown feature name.
+    """
+    valid_names = set(NUMERIC_FEATURES) | set(CATEGORICAL_FEATURES)
+    for dist in config.distributions:
+        if dist.feature not in valid_names:
+            raise ValueError(
+                f"Unknown feature in distribution override: '{dist.feature}'. "
+                f"Valid features: {sorted(valid_names)}"
+            )

--- a/shared/schemas/__init__.py
+++ b/shared/schemas/__init__.py
@@ -20,6 +20,12 @@ from shared.schemas.prediction import (
     PredictionResponse,
     PredictionResult,
 )
+from shared.schemas.synthetic import (
+    SyntheticConfig,
+    SyntheticDataset,
+    SyntheticDistribution,
+    SyntheticGenerateResponse,
+)
 from shared.schemas.training import TrainingConfig, TrainingResult
 
 __all__ = [
@@ -44,6 +50,11 @@ __all__ = [
     "PredictionRequest",
     "PredictionResponse",
     "PredictionResult",
+    # Synthetic
+    "SyntheticConfig",
+    "SyntheticDataset",
+    "SyntheticDistribution",
+    "SyntheticGenerateResponse",
     # Training
     "TrainingConfig",
     "TrainingResult",

--- a/shared/schemas/synthetic.py
+++ b/shared/schemas/synthetic.py
@@ -1,0 +1,84 @@
+"""Synthetic data generation schemas."""
+
+from pydantic import BaseModel, Field
+
+
+class SyntheticDistribution(BaseModel):
+    """Per-feature distribution override for synthetic data generation.
+
+    Attributes:
+        feature: Feature name (must be in NUMERIC_FEATURES or CATEGORICAL_FEATURES).
+        mean_shift: Additive shift to feature mean (numeric only).
+        std_scale: Std deviation scale factor (numeric only).
+        category_weights: Override category probability weights (categorical only).
+    """
+
+    feature: str = Field(
+        description="Feature name (must be in NUMERIC_FEATURES or CATEGORICAL_FEATURES)"
+    )
+    mean_shift: float = Field(
+        default=0.0, description="Additive shift to feature mean (numeric only)"
+    )
+    std_scale: float = Field(
+        default=1.0, gt=0.0, description="Std deviation scale factor (numeric only)"
+    )
+    category_weights: dict[str, float] | None = Field(
+        default=None,
+        description="Override category probability weights (categorical only)",
+    )
+
+
+class SyntheticConfig(BaseModel):
+    """Configuration for synthetic dataset generation.
+
+    Attributes:
+        n_samples: Number of samples to generate.
+        default_rate: Target default rate for the generated dataset.
+        distributions: Per-feature distribution overrides.
+        random_seed: Random seed for reproducibility (None for random).
+    """
+
+    n_samples: int = Field(
+        default=5000, ge=100, le=50000, description="Number of samples"
+    )
+    default_rate: float = Field(
+        default=0.22, ge=0.01, le=0.99, description="Target default rate"
+    )
+    distributions: list[SyntheticDistribution] = Field(
+        default_factory=list, description="Per-feature distribution overrides"
+    )
+    random_seed: int | None = Field(
+        default=42, description="Random seed (None for random)"
+    )
+
+
+class SyntheticDataset(BaseModel):
+    """Metadata for a generated synthetic dataset.
+
+    Attributes:
+        n_samples: Number of samples in the dataset.
+        n_features: Number of features in the dataset.
+        default_rate_actual: Actual default rate in the generated dataset.
+        feature_names: Ordered list of feature column names.
+        summary_stats: Per-feature summary statistics (mean, std, min, max).
+    """
+
+    n_samples: int = Field(ge=1)
+    n_features: int = Field(ge=1)
+    default_rate_actual: float = Field(ge=0.0, le=1.0)
+    feature_names: list[str]
+    summary_stats: dict[str, dict[str, float]] = Field(
+        description="feature_name -> {mean, std, min, max}"
+    )
+
+
+class SyntheticGenerateResponse(BaseModel):
+    """API response from synthetic data generation.
+
+    Attributes:
+        dataset_id: Unique identifier for the generated dataset.
+        metadata: Metadata about the generated dataset.
+    """
+
+    dataset_id: str = Field(description="Unique identifier for the generated dataset")
+    metadata: SyntheticDataset

--- a/tests/shared/test_synthetic.py
+++ b/tests/shared/test_synthetic.py
@@ -1,0 +1,181 @@
+"""Tests for synthetic data generator."""
+
+import numpy as np
+import pytest
+
+from shared.constants import ALL_FEATURES, NUMERIC_FEATURE_DEFAULTS, NUMERIC_FEATURES
+from shared.logic.synthetic import generate_synthetic_dataset
+from shared.schemas.synthetic import SyntheticConfig, SyntheticDistribution
+
+
+class TestGenerateSyntheticDataset:
+    """Tests for the generate_synthetic_dataset function."""
+
+    def test_output_shapes(self) -> None:
+        config = SyntheticConfig(n_samples=1000, random_seed=42)
+        X, y, feature_names, metadata = generate_synthetic_dataset(config)
+        assert X.shape == (1000, 26)
+        assert y.shape == (1000,)
+
+    def test_feature_names_match_all_features(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=42)
+        _, _, feature_names, _ = generate_synthetic_dataset(config)
+        assert feature_names == ALL_FEATURES
+
+    def test_default_rate_approximately_correct(self) -> None:
+        config = SyntheticConfig(n_samples=5000, default_rate=0.30, random_seed=42)
+        _, y, _, metadata = generate_synthetic_dataset(config)
+        actual_rate = float(np.mean(y))
+        assert abs(actual_rate - 0.30) < 0.05
+
+    def test_deterministic_with_same_seed(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=123)
+        X1, y1, _, _ = generate_synthetic_dataset(config)
+        X2, y2, _, _ = generate_synthetic_dataset(config)
+        np.testing.assert_array_equal(X1, X2)
+        np.testing.assert_array_equal(y1, y2)
+
+    def test_different_output_with_no_seed(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=None)
+        X1, _, _, _ = generate_synthetic_dataset(config)
+        X2, _, _, _ = generate_synthetic_dataset(config)
+        # Extremely unlikely to be identical with random seeds
+        assert not np.array_equal(X1, X2)
+
+    def test_numeric_features_within_bounds(self) -> None:
+        config = SyntheticConfig(n_samples=2000, random_seed=42)
+        X, _, feature_names, _ = generate_synthetic_dataset(config)
+        for feat in NUMERIC_FEATURES:
+            col_idx = feature_names.index(feat)
+            col = X[:, col_idx]
+            bounds = NUMERIC_FEATURE_DEFAULTS[feat]
+            assert float(np.min(col)) >= bounds["min"], f"{feat} below min"
+            assert float(np.max(col)) <= bounds["max"], f"{feat} above max"
+
+    def test_categorical_valid_one_hot(self) -> None:
+        """Each categorical group must have exactly one 1.0 per row, rest 0.0."""
+        config = SyntheticConfig(n_samples=1000, random_seed=42)
+        X, _, feature_names, _ = generate_synthetic_dataset(config)
+
+        from shared.constants import CATEGORICAL_FEATURES, FEATURE_GROUPS
+
+        for cat_feat in CATEGORICAL_FEATURES:
+            encoded_cols = FEATURE_GROUPS[cat_feat]
+            col_indices = [feature_names.index(c) for c in encoded_cols]
+            group_data = X[:, col_indices]
+
+            # Each row should sum to exactly 1.0
+            row_sums = group_data.sum(axis=1)
+            np.testing.assert_array_almost_equal(row_sums, 1.0)
+
+            # Each value should be 0.0 or 1.0
+            unique_vals = np.unique(group_data)
+            assert set(unique_vals) == {0.0, 1.0}
+
+    def test_mean_shift_changes_mean(self) -> None:
+        base_config = SyntheticConfig(n_samples=5000, random_seed=42)
+        shifted_config = SyntheticConfig(
+            n_samples=5000,
+            random_seed=42,
+            distributions=[
+                SyntheticDistribution(feature="person_age", mean_shift=10.0),
+            ],
+        )
+        X_base, _, names, _ = generate_synthetic_dataset(base_config)
+        X_shifted, _, _, _ = generate_synthetic_dataset(shifted_config)
+
+        age_idx = names.index("person_age")
+        base_mean = float(np.mean(X_base[:, age_idx]))
+        shifted_mean = float(np.mean(X_shifted[:, age_idx]))
+        # Shifted mean should be higher (allowing for clipping effects)
+        assert shifted_mean > base_mean
+
+    def test_std_scale_changes_variance(self) -> None:
+        base_config = SyntheticConfig(n_samples=5000, random_seed=42)
+        scaled_config = SyntheticConfig(
+            n_samples=5000,
+            random_seed=42,
+            distributions=[
+                SyntheticDistribution(feature="loan_int_rate", std_scale=2.0),
+            ],
+        )
+        X_base, _, names, _ = generate_synthetic_dataset(base_config)
+        X_scaled, _, _, _ = generate_synthetic_dataset(scaled_config)
+
+        idx = names.index("loan_int_rate")
+        base_var = float(np.var(X_base[:, idx]))
+        scaled_var = float(np.var(X_scaled[:, idx]))
+        # Variance should increase (roughly 4x, but clipping reduces it)
+        assert scaled_var > base_var * 1.5
+
+    def test_category_weights_override(self) -> None:
+        config = SyntheticConfig(
+            n_samples=5000,
+            random_seed=42,
+            distributions=[
+                SyntheticDistribution(
+                    feature="cb_person_default_on_file",
+                    category_weights={"N": 0.1, "Y": 0.9},
+                ),
+            ],
+        )
+        X, _, names, _ = generate_synthetic_dataset(config)
+        y_idx = names.index("cb_person_default_on_file_Y")
+        proportion_y = float(np.mean(X[:, y_idx]))
+        # Should be close to 0.9
+        assert proportion_y > 0.85
+
+    def test_edge_case_min_samples(self) -> None:
+        config = SyntheticConfig(n_samples=100, random_seed=42)
+        X, y, _, metadata = generate_synthetic_dataset(config)
+        assert X.shape[0] == 100
+        assert y.shape[0] == 100
+        assert metadata.n_samples == 100
+
+    def test_edge_case_low_default_rate(self) -> None:
+        config = SyntheticConfig(n_samples=1000, default_rate=0.01, random_seed=42)
+        _, y, _, _ = generate_synthetic_dataset(config)
+        actual_rate = float(np.mean(y))
+        assert actual_rate < 0.05
+
+    def test_edge_case_high_default_rate(self) -> None:
+        config = SyntheticConfig(n_samples=1000, default_rate=0.99, random_seed=42)
+        _, y, _, _ = generate_synthetic_dataset(config)
+        actual_rate = float(np.mean(y))
+        assert actual_rate > 0.95
+
+    def test_invalid_feature_name_raises_error(self) -> None:
+        config = SyntheticConfig(
+            distributions=[
+                SyntheticDistribution(feature="nonexistent_feature"),
+            ]
+        )
+        with pytest.raises(ValueError, match="Unknown feature"):
+            generate_synthetic_dataset(config)
+
+    def test_metadata_summary_stats_all_features(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=42)
+        _, _, _, metadata = generate_synthetic_dataset(config)
+        assert len(metadata.summary_stats) == 26
+        for feat_name in ALL_FEATURES:
+            assert feat_name in metadata.summary_stats
+            stats = metadata.summary_stats[feat_name]
+            assert "mean" in stats
+            assert "std" in stats
+            assert "min" in stats
+            assert "max" in stats
+
+    def test_metadata_n_features(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=42)
+        _, _, _, metadata = generate_synthetic_dataset(config)
+        assert metadata.n_features == 26
+
+    def test_y_dtype_is_integer(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=42)
+        _, y, _, _ = generate_synthetic_dataset(config)
+        assert np.issubdtype(y.dtype, np.integer)
+
+    def test_y_values_binary(self) -> None:
+        config = SyntheticConfig(n_samples=500, random_seed=42)
+        _, y, _, _ = generate_synthetic_dataset(config)
+        assert set(np.unique(y)) <= {0, 1}

--- a/tests/shared/test_synthetic_schemas.py
+++ b/tests/shared/test_synthetic_schemas.py
@@ -1,0 +1,130 @@
+"""Tests for synthetic data generation schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from shared.schemas.synthetic import (
+    SyntheticConfig,
+    SyntheticDataset,
+    SyntheticDistribution,
+    SyntheticGenerateResponse,
+)
+
+
+class TestSyntheticDistribution:
+    """Tests for SyntheticDistribution schema."""
+
+    def test_valid_with_all_fields(self) -> None:
+        dist = SyntheticDistribution(
+            feature="person_age",
+            mean_shift=5.0,
+            std_scale=2.0,
+            category_weights=None,
+        )
+        assert dist.feature == "person_age"
+        assert dist.mean_shift == 5.0
+        assert dist.std_scale == 2.0
+        assert dist.category_weights is None
+
+    def test_valid_with_category_weights(self) -> None:
+        dist = SyntheticDistribution(
+            feature="loan_grade",
+            category_weights={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        assert dist.category_weights == {"A": 0.5, "B": 0.3, "C": 0.2}
+        assert dist.mean_shift == 0.0
+        assert dist.std_scale == 1.0
+
+    def test_std_scale_zero_invalid(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticDistribution(feature="person_age", std_scale=0.0)
+
+    def test_std_scale_negative_invalid(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticDistribution(feature="person_age", std_scale=-1.0)
+
+
+class TestSyntheticConfig:
+    """Tests for SyntheticConfig schema."""
+
+    def test_valid_defaults(self) -> None:
+        config = SyntheticConfig()
+        assert config.n_samples == 5000
+        assert config.default_rate == 0.22
+        assert config.distributions == []
+        assert config.random_seed == 42
+
+    def test_n_samples_below_minimum(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticConfig(n_samples=99)
+
+    def test_n_samples_above_maximum(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticConfig(n_samples=50001)
+
+    def test_n_samples_at_bounds(self) -> None:
+        config_min = SyntheticConfig(n_samples=100)
+        assert config_min.n_samples == 100
+        config_max = SyntheticConfig(n_samples=50000)
+        assert config_max.n_samples == 50000
+
+    def test_default_rate_below_minimum(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticConfig(default_rate=0.001)
+
+    def test_default_rate_above_maximum(self) -> None:
+        with pytest.raises(ValidationError):
+            SyntheticConfig(default_rate=0.999)
+
+    def test_default_rate_at_bounds(self) -> None:
+        config_low = SyntheticConfig(default_rate=0.01)
+        assert config_low.default_rate == 0.01
+        config_high = SyntheticConfig(default_rate=0.99)
+        assert config_high.default_rate == 0.99
+
+    def test_random_seed_none(self) -> None:
+        config = SyntheticConfig(random_seed=None)
+        assert config.random_seed is None
+
+    def test_with_distributions(self) -> None:
+        config = SyntheticConfig(
+            distributions=[
+                SyntheticDistribution(feature="person_age", mean_shift=5.0),
+            ]
+        )
+        assert len(config.distributions) == 1
+        assert config.distributions[0].feature == "person_age"
+
+
+class TestSyntheticDataset:
+    """Tests for SyntheticDataset schema."""
+
+    def test_valid(self) -> None:
+        dataset = SyntheticDataset(
+            n_samples=1000,
+            n_features=26,
+            default_rate_actual=0.22,
+            feature_names=["f1", "f2"],
+            summary_stats={"f1": {"mean": 1.0, "std": 0.5, "min": 0.0, "max": 2.0}},
+        )
+        assert dataset.n_samples == 1000
+        assert dataset.n_features == 26
+        assert dataset.default_rate_actual == 0.22
+
+
+class TestSyntheticGenerateResponse:
+    """Tests for SyntheticGenerateResponse schema."""
+
+    def test_valid(self) -> None:
+        response = SyntheticGenerateResponse(
+            dataset_id="syn_abc123",
+            metadata=SyntheticDataset(
+                n_samples=1000,
+                n_features=26,
+                default_rate_actual=0.22,
+                feature_names=["f1"],
+                summary_stats={"f1": {"mean": 1.0, "std": 0.5, "min": 0.0, "max": 2.0}},
+            ),
+        )
+        assert response.dataset_id == "syn_abc123"
+        assert response.metadata.n_samples == 1000


### PR DESCRIPTION
## Summary
- Add `shared/schemas/synthetic.py` with Pydantic v2 schemas for synthetic data config and metadata
- Add `shared/logic/synthetic.py` with numpy-based generator using multivariate normal sampling (preserves feature correlations)
- Add feature distribution constants and correlation matrix to `shared/constants.py`
- Add 4 named presets: Stress Test, Low Default, Large Sample, Balanced

## Test plan
- [ ] `uv run pytest tests/shared/test_synthetic_schemas.py -v` — schema validation (15 tests)
- [ ] `uv run pytest tests/shared/test_synthetic.py -v` — generator correctness, shapes, bounds, determinism (18 tests)
- [ ] `uv run pytest tests/shared/ -v` — no regressions (124 tests pass)
- [ ] `uv run ruff check shared/` — linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)