### PR TITLE
docs: update RFCs and changelog for synthetic data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [shared] Synthetic data generation schemas and numpy-based generator with correlation preservation (#56)
+- [shared] Named presets for synthetic generation: Stress Test, Low Default, Large Sample, Balanced (#56)
+- [api] `POST /synthetic/generate/` endpoint with in-memory dataset store (#57)
+- [api] `dataset_id` field on `TrainingConfig` for training on synthetic data (#57)
+- [api] `data_source` field on `ModelMetadata` for provenance tracking (#57)
+- [gradio] Synthetic Data tab with preset selection and train-on-synthetic workflow (#58)
+- [web] `/synthetic` page with generation controls, summary stats, and training (#60)
+- [web] Synthetic data source badge on compare page (#60)
+- [marimo] Synthetic data exploration notebook with real vs synthetic comparison (#59)
+
+### Changed
+- [docs] Replace "User Uploads" with "Synthetic Data" in RFC-001 architecture diagrams
+
 ### Fixed
 
 - [web] Number input step validation rejecting valid income, employment length, and loan amount values

--- a/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
+++ b/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
@@ -88,7 +88,7 @@ Three-tier architecture with progressive UI fidelity:
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                      Data Layer                             │
-│         cr_loan_w2.csv | User Uploads | Artifacts           │
+│         cr_loan_w2.csv | Synthetic Data | Artifacts         │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -116,7 +116,7 @@ flowchart TB
 
     subgraph "Data Layer"
         CSV["cr_loan_w2.csv"]
-        UPLOAD["User Uploads"]
+        SYNTH["Synthetic Data"]
         ARTIFACTS["Model Artifacts"]
     end
 
@@ -127,7 +127,7 @@ flowchart TB
     API --> SCHEMAS
     API --> LOGIC
     TRAIN --> CSV
-    TRAIN --> UPLOAD
+    TRAIN --> SYNTH
     PREDICT --> ARTIFACTS
 ```
 

--- a/docs/0-RFCs/RFC-007-data-input-strategy.md
+++ b/docs/0-RFCs/RFC-007-data-input-strategy.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Draft |
+| Status | Implemented |
 | Author(s) | pkiage |
 | Updated | 2026-02-13 |
 | Depends On | [RFC-001](RFC-001-CreditRiskPlatformArchitecture.md), [RFC-002](RFC-002-api-layer.md) |


### PR DESCRIPTION
## Summary
- Replace "User Uploads" with "Synthetic Data" in RFC-001 architecture diagrams (3 references)
- Mark RFC-007 status as Implemented
- Add changelog entries for all synthetic data features (PRs #56-#60)

## Test plan
- [ ] RFC-001 Mermaid diagram renders correctly with "Synthetic Data" node
- [ ] RFC-007 shows "Implemented" status
- [ ] CHANGELOG.md entries are under correct `[Unreleased]` section
- [ ] No remaining "User Upload" references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)