### PR TITLE
docs: update RFCs, ADRs, and deployment docs for current state

### DIFF
--- a/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
+++ b/docs/0-RFCs/RFC-001-CreditRiskPlatformArchitecture.md
@@ -366,12 +366,12 @@ See inline code examples above. Full implementation in:
 
 ### 2. Auth strategy — None for demo, API key, or OAuth?
 
-**Decision: None for Phases 2-3. API key for Phase 4. OAuth if multi-tenant is ever needed.**
+**Decision: API key auth was built in Phase 4 ([RFC-006](RFC-006-auth-polish.md)), then removed from Web ([ADR-013](../1-ADRs/ADR-013-remove-web-authentication.md)) and Gradio ([ADR-014](../1-ADRs/ADR-014-remove-gradio-authentication.md)) layers.**
 
-- The RFC explicitly lists multi-tenant auth as a non-goal. Adding auth now would slow down iteration on the core ML workflows (Marimo, Gradio, Next.js) without protecting anything valuable — the API is local-only and trains on a bundled demo dataset.
-- Phase 4 (when Next.js ships): add a simple API key via `X-API-Key` header, validated in a FastAPI dependency. This is a ~20-line change: one `Settings` field, one `Depends()` function, one middleware. It's enough to prevent accidental public exposure if deployed behind a URL.
-- OAuth/OIDC is only justified if the platform becomes multi-tenant (multiple users, per-user model storage, RBAC). The RFC says this is a non-goal, so don't build toward it unless requirements change.
-- When auth is added, lock down CORS origins at the same time (see RFC-002 Q3).
+- API key authentication was implemented across all layers (API, Web, Gradio) as planned.
+- However, since the API defaults to `require_auth=false` and the platform is a development/demo tool, the Web and Gradio auth layers were removed as they added friction without providing actual security.
+- The API retains its auth module (`apps/api/auth.py`) and can be re-enabled via `CREDIT_RISK_REQUIRE_AUTH=true`. See ADR-013 and ADR-014 for the full rationale and re-enablement path.
+- OAuth/OIDC remains a non-goal unless the platform becomes multi-tenant.
 
 ### 3. Chart library for Next.js — Recharts, Plotly.js, or Nivo?
 
@@ -409,3 +409,4 @@ See inline code examples above. Full implementation in:
 |------|--------|---------|
 | 2025-01-30 | Claude | Initial draft |
 | 2026-02-01 | Claude | Update status to Accepted, sync TrainingResult schema with implementation |
+| 2026-02-14 | Claude | Update auth Q&A to reflect ADR-013/ADR-014 auth removal |

--- a/docs/0-RFCs/RFC-002-api-layer.md
+++ b/docs/0-RFCs/RFC-002-api-layer.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | Status | Implemented |
 | Author(s) | Paul / Claude |
-| Updated | 2026-02-01 |
+| Updated | 2026-02-14 |
 | Depends On | RFC-001 |
 
 ## Objective
@@ -49,14 +49,21 @@ apps/api/
 ├── dependencies.py         # Request-scoped dependencies
 ├── routers/
 │   ├── __init__.py
+│   ├── auth.py             # /auth (verify key)
 │   ├── train.py            # POST /train
 │   ├── predict.py          # POST /predict
-│   └── models.py           # GET/POST /models
+│   ├── models.py           # GET/POST /models
+│   ├── feature_selection.py # POST /feature-selection
+│   └── synthetic.py        # POST /synthetic/generate
 ├── services/
 │   ├── __init__.py
 │   ├── training.py         # Training orchestration
 │   ├── inference.py        # Prediction logic
-│   └── audit.py            # Audit event emission
+│   ├── audit.py            # Audit event emission
+│   ├── model_store.py      # In-memory model storage
+│   ├── persistent_model_store.py # Filesystem persistence
+│   ├── feature_selection_service.py # Feature selection logic
+│   └── synthetic_store.py  # Synthetic data generation
 └── tests/
     ├── conftest.py
     ├── test_train.py
@@ -71,6 +78,8 @@ apps/api/
 | `POST` | `/predict` | `PredictionRequest` | `PredictionResponse` | Run inference |
 | `GET` | `/models` | — | `list[ModelSummary]` | List session models |
 | `POST` | `/models/{id}/persist` | — | `PersistResponse` | Save artifact |
+| `POST` | `/feature-selection` | `FeatureSelectionRequest` | `FeatureSelectionResult` | Run feature selection |
+| `POST` | `/synthetic/generate` | `SyntheticGenerateRequest` | `SyntheticGenerateResponse` | Generate synthetic data |
 | `GET` | `/health` | — | `{"status": "ok"}` | Health check |
 
 ### Training Flow
@@ -292,3 +301,4 @@ After implementation:
 |------|--------|---------|
 | 2025-01-31 | — | Initial draft |
 | 2026-02-01 | Claude | Update status to Accepted, all open questions resolved |
+| 2026-02-14 | Claude | Add feature-selection and synthetic endpoints, update directory structure |

--- a/docs/0-RFCs/RFC-006-auth-polish.md
+++ b/docs/0-RFCs/RFC-006-auth-polish.md
@@ -2,10 +2,12 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Implemented |
+| Status | Partially Superseded |
 | Author(s) | pkiage |
-| Updated | 2026-02-02 |
+| Updated | 2026-02-14 |
 | Depends On | [RFC-001](RFC-001-CreditRiskPlatformArchitecture.md), [RFC-002](RFC-002-api-layer.md) |
+
+> **Note (2026-02-14):** The authentication portions of this RFC were implemented and then intentionally removed from the Web and Gradio layers per [ADR-013](../1-ADRs/ADR-013-remove-web-authentication.md) and [ADR-014](../1-ADRs/ADR-014-remove-gradio-authentication.md). The API retains its auth module but defaults to `require_auth=false`. Non-auth features (CORS, rate limiting, model persistence, error handling) remain implemented. See the ADRs for rationale and re-enablement path.
 
 ## Objective
 
@@ -460,3 +462,4 @@ class Settings(BaseSettings):
 | Date | Author | Changes |
 |------|--------|---------|
 | 2025-01-31 | — | Initial draft |
+| 2026-02-14 | Claude | Mark partially superseded; auth removed per ADR-013/ADR-014 |

--- a/docs/0-RFCs/RFC-README.md
+++ b/docs/0-RFCs/RFC-README.md
@@ -7,6 +7,8 @@ This directory contains RFCs (Requests for Comments) for the Credit Risk Platfor
 | RFC | Title | Status | Updated |
 |-----|-------|--------|---------|
 | [RFC-001](RFC-001-CreditRiskPlatformArchitecture.md) | Credit Risk Modeling Platform Architecture | Implemented | 2026-02-01 |
-| [RFC-002](RFC-002-api-layer.md) | FastAPI Service Layer | Implemented | 2026-02-01 |
-| [RFC-006](RFC-006-auth-polish.md) | Authentication & Production Polish | Implemented | 2026-02-02 |
-| [RFC-007](RFC-007-gradio-data-input-strategy.md) | Platform-Wide Synthetic Data Generation for Testing and Comparison | Draft | 2026-02-13 |
+| [RFC-002](RFC-002-api-layer.md) | FastAPI Service Layer | Implemented | 2026-02-14 |
+| [RFC-006](RFC-006-auth-polish.md) | Authentication & Production Polish | Partially Superseded | 2026-02-14 |
+| [RFC-007](RFC-007-data-input-strategy.md) | Platform-Wide Synthetic Data Generation for Testing and Comparison | Implemented | 2026-02-13 |
+
+> **Note:** RFC-003 through RFC-005 were never created. The numbering jumped from RFC-002 to RFC-006 because related decisions (Pydantic contracts, Marimo choice, auth approach) were captured as ADRs instead of full RFCs. See the [ADR index](../1-ADRs/ADR-README.md) for those decisions.

--- a/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
+++ b/docs/1-ADRs/ADR-011-nextjs-cloud-run.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Proposed |
+| Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-07 |
 | PR | [#37](https://github.com/pkiage/tool-credit-risk-modelling/pull/37) |

--- a/docs/1-ADRs/ADR-013-remove-web-authentication.md
+++ b/docs/1-ADRs/ADR-013-remove-web-authentication.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Proposed |
+| Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-08 |
 | PR | [#44](https://github.com/pkiage/tool-credit-risk-modelling/pull/44) |
@@ -120,7 +120,7 @@ Rely on web-layer authentication only.
 
 ## Implementation
 
-Changes made in PR #[TBD]:
+Changes made in [PR #44](https://github.com/pkiage/tool-credit-risk-modelling/pull/44):
 
 **Deleted files:**
 - `apps/web/app/login/page.tsx` (87 lines) - Login form component

--- a/docs/1-ADRs/ADR-014-remove-gradio-authentication.md
+++ b/docs/1-ADRs/ADR-014-remove-gradio-authentication.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Proposed |
+| Status | Accepted |
 | Author | Paul / Claude |
 | Date | 2026-02-08 |
 | PR | [#45](https://github.com/pkiage/tool-credit-risk-modelling/pull/45) |
@@ -124,7 +124,7 @@ Rely on Gradio-layer authentication only.
 
 ## Implementation
 
-Changes made in PR #[TBD]:
+Changes made in [PR #45](https://github.com/pkiage/tool-credit-risk-modelling/pull/45):
 
 **Modified files:**
 - `apps/gradio/app.py` - Removed:

--- a/docs/1-ADRs/ADR-015-dark-mode-accessibility.md
+++ b/docs/1-ADRs/ADR-015-dark-mode-accessibility.md
@@ -1,0 +1,77 @@
+# ADR-015: Dark Mode and Accessibility Standards
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Author | Paul / Claude |
+| Date | 2026-02-08 |
+| PR | [#46](https://github.com/pkiage/tool-credit-risk-modelling/pull/46), [#48](https://github.com/pkiage/tool-credit-risk-modelling/pull/48) |
+
+## Context
+
+The Next.js web application needed dark mode support for developer ergonomics and accessibility. Users working in low-light environments or with visual preferences for dark backgrounds should be accommodated. The implementation also needed to meet color contrast standards for accessibility compliance.
+
+Key requirements:
+
+- Support light, dark, and system-preference themes
+- Persist user preference across sessions
+- Maintain readable contrast ratios across all themes
+- Work with existing Tailwind CSS setup and Recharts visualizations
+
+## Decision
+
+Implement dark mode using **CSS custom properties (variables) with Tailwind CSS class-based toggling** and a custom `ThemeProvider` React context. Target **WCAG AAA color contrast** (7:1 ratio for normal text) across both themes.
+
+### Implementation
+
+1. **ThemeProvider** (`lib/theme-provider.tsx`): Custom React context supporting three modes — `light`, `dark`, `system` — with `localStorage` persistence and `prefers-color-scheme` media query listener
+2. **CSS variables** (`globals.css`): Semantic color tokens (e.g., `--foreground`, `--surface`, `--border`) defined for both light and dark themes
+3. **ThemeToggle** (`components/ui/theme-toggle.tsx`): Three-state toggle button (light → dark → system) with SVG icons and accessible `aria-label`
+4. **Tailwind dark mode**: Configured as `class` strategy, toggled by the ThemeProvider adding/removing `dark` on `<html>`
+
+### Accessibility
+
+- WCAG AAA contrast ratios (7:1) for all text against backgrounds in both themes
+- Distinct focus ring styles (`focus:ring-2 focus:ring-focus-ring`)
+- `aria-label` on theme toggle with current state
+- `aria-hidden="true"` on decorative SVG icons
+
+## Consequences
+
+### Positive
+
+- Users can work in their preferred color scheme
+- System preference detection provides good defaults
+- CSS variables make it straightforward to add new themed components
+- WCAG AAA compliance exceeds most accessibility requirements
+
+### Negative
+
+- Custom ThemeProvider adds client-side JavaScript; brief flash of light theme possible on first load before hydration
+- Chart colors (Recharts) must be coordinated with theme variables — each new chart must consider both themes
+- Two color palettes to maintain going forward
+
+### Neutral
+
+- Gradio and Marimo layers are unaffected — they use their own theming systems
+- The approach does not use `next-themes` (a popular library) to avoid an extra dependency for a straightforward use case
+
+## Alternatives Considered
+
+### Alternative 1: next-themes library
+
+Drop-in dark mode for Next.js with SSR flash prevention via script injection.
+
+**Why not chosen:** Adds a dependency for functionality achievable with ~70 lines of custom code. The custom ThemeProvider is simpler to understand and modify.
+
+### Alternative 2: Tailwind `media` strategy
+
+Use `@media (prefers-color-scheme: dark)` instead of class-based toggling.
+
+**Why not chosen:** No manual override — users cannot choose a theme different from their OS preference. The three-state toggle (light/dark/system) requires class-based control.
+
+### Alternative 3: WCAG AA instead of AAA
+
+Target 4.5:1 contrast ratio (AA) instead of 7:1 (AAA).
+
+**Why not chosen:** The stricter AAA standard was achievable with minimal design trade-offs and provides better readability for all users.

--- a/docs/1-ADRs/ADR-README.md
+++ b/docs/1-ADRs/ADR-README.md
@@ -16,10 +16,11 @@ This directory contains Architecture Decision Records (ADRs) for the Credit Risk
 | [ADR-008](ADR-008-monorepo-structure.md) | Monorepo Structure | Accepted | 2026-02-02 | [#21](https://github.com/pkiage/tool-credit-risk-modelling/pull/21) |
 | [ADR-009](ADR-009-cloud-run-deployment.md) | Cloud Run Deployment | Accepted | 2026-02-07 | [#30](https://github.com/pkiage/tool-credit-risk-modelling/pull/30) |
 | [ADR-010](ADR-010-feature-selection.md) | Training Feature Selection | Accepted | 2026-02-07 | [#31](https://github.com/pkiage/tool-credit-risk-modelling/pull/31) |
-| [ADR-011](ADR-011-nextjs-cloud-run.md) | Next.js Deployment on Cloud Run | Proposed | 2026-02-07 | [#37](https://github.com/pkiage/tool-credit-risk-modelling/pull/37) |
+| [ADR-011](ADR-011-nextjs-cloud-run.md) | Next.js Deployment on Cloud Run | Accepted | 2026-02-07 | [#37](https://github.com/pkiage/tool-credit-risk-modelling/pull/37) |
 | [ADR-012](ADR-012-automatic-feature-selection.md) | Automatic Feature Selection Methods | Accepted | 2026-02-07 | [#38](https://github.com/pkiage/tool-credit-risk-modelling/pull/38), [#39](https://github.com/pkiage/tool-credit-risk-modelling/pull/39) |
-| [ADR-013](ADR-013-remove-web-authentication.md) | Remove Web Authentication Layer | Proposed | 2026-02-08 | [#44](https://github.com/pkiage/tool-credit-risk-modelling/pull/44) |
-| [ADR-014](ADR-014-remove-gradio-authentication.md) | Remove Gradio Authentication Layer | Proposed | 2026-02-08 | [#45](https://github.com/pkiage/tool-credit-risk-modelling/pull/45) |
+| [ADR-013](ADR-013-remove-web-authentication.md) | Remove Web Authentication Layer | Accepted | 2026-02-08 | [#44](https://github.com/pkiage/tool-credit-risk-modelling/pull/44) |
+| [ADR-014](ADR-014-remove-gradio-authentication.md) | Remove Gradio Authentication Layer | Accepted | 2026-02-08 | [#45](https://github.com/pkiage/tool-credit-risk-modelling/pull/45) |
+| [ADR-015](ADR-015-dark-mode-accessibility.md) | Dark Mode and Accessibility Standards | Accepted | 2026-02-08 | [#46](https://github.com/pkiage/tool-credit-risk-modelling/pull/46), [#48](https://github.com/pkiage/tool-credit-risk-modelling/pull/48) |
 
 ## Creating a New ADR
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -36,7 +36,9 @@ cd apps/web && npm run dev
 uv run python -m apps.gradio.app
 ```
 
-### Start with Authentication
+### Start with Authentication (Optional)
+
+> **Note:** Authentication is disabled by default (`require_auth=false`). The Web and Gradio layers do not enforce authentication — see [ADR-013](1-ADRs/ADR-013-remove-web-authentication.md) and [ADR-014](1-ADRs/ADR-014-remove-gradio-authentication.md). To enable API-level auth:
 
 ```bash
 CREDIT_RISK_REQUIRE_AUTH=true \


### PR DESCRIPTION
## Summary

- Update ADR-011, ADR-013, ADR-014 status from Proposed to Accepted (all implemented and merged)
- Fix `PR #[TBD]` placeholders in ADR-013 and ADR-014 with actual PR links
- Mark RFC-006 as Partially Superseded — auth built then removed per ADR-013/014
- Update RFC-001 Q&A auth answer to reflect auth removal decisions
- Update RFC-002 endpoint table with `/feature-selection` and `/synthetic/generate`, update directory structure
- Fix RFC-README broken link to RFC-007 and update status from Draft to Implemented
- Add note explaining RFC-003 through RFC-005 numbering gap
- Create ADR-015: Dark Mode and Accessibility Standards (documenting PRs #46, #48)
- Update DEPLOYMENT.md auth section to clarify it is optional, reference ADRs

## Test plan

- [ ] All markdown links resolve correctly
- [ ] ADR/RFC index tables match file contents
- [ ] No broken cross-references between docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)